### PR TITLE
Disallow CBOR Tags

### DIFF
--- a/cbor.go
+++ b/cbor.go
@@ -12,8 +12,9 @@ const (
 
 // Pre-configured modes for CBOR encoding and decoding.
 var (
-	encMode cbor.EncMode
-	decMode cbor.DecMode
+	encMode                  cbor.EncMode
+	decMode                  cbor.DecMode
+	decModeWithTagsForbidden cbor.DecMode
 )
 
 func init() {
@@ -36,6 +37,11 @@ func init() {
 		IntDec:      cbor.IntDecConvertSigned,  // decode CBOR uint/int to Go int64
 	}
 	decMode, err = decOpts.DecMode()
+	if err != nil {
+		panic(err)
+	}
+	decOpts.TagsMd = cbor.TagsForbidden
+	decModeWithTagsForbidden, err = decOpts.DecMode()
 	if err != nil {
 		panic(err)
 	}

--- a/sign.go
+++ b/sign.go
@@ -71,7 +71,7 @@ func (s *Signature) UnmarshalCBOR(data []byte) error {
 
 	// decode to signature and parse
 	var raw signature
-	if err := decMode.Unmarshal(data, &raw); err != nil {
+	if err := decModeWithTagsForbidden.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 	if len(raw.Signature) == 0 {
@@ -287,7 +287,7 @@ func (m *SignMessage) UnmarshalCBOR(data []byte) error {
 
 	// decode to signMessage and parse
 	var raw signMessage
-	if err := decMode.Unmarshal(data[2:], &raw); err != nil {
+	if err := decModeWithTagsForbidden.Unmarshal(data[2:], &raw); err != nil {
 		return err
 	}
 	if len(raw.Signatures) == 0 {

--- a/sign1.go
+++ b/sign1.go
@@ -89,7 +89,7 @@ func (m *Sign1Message) UnmarshalCBOR(data []byte) error {
 
 	// decode to sign1Message and parse
 	var raw sign1Message
-	if err := decMode.Unmarshal(data[1:], &raw); err != nil {
+	if err := decModeWithTagsForbidden.Unmarshal(data[1:], &raw); err != nil {
 		return err
 	}
 	if len(raw.Signature) == 0 {


### PR DESCRIPTION
Disallow CBOR tags for `Signature`, `SignMessage` and `Sign1Message`. The value of header maps can still have tags.

Fix #34 