### PR TITLE
Add Sign1Message benchmarks

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,105 @@
+package cose_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/veraison/go-cose"
+)
+
+func newSign1Message() *cose.Sign1Message {
+	return &cose.Sign1Message{
+		Headers: cose.Headers{
+			Protected: cose.ProtectedHeader{
+				cose.HeaderLabelAlgorithm: cose.AlgorithmES256,
+			},
+			Unprotected: cose.UnprotectedHeader{
+				cose.HeaderLabelKeyID: 1,
+			},
+		},
+		Payload:   make([]byte, 100),
+		Signature: make([]byte, 32),
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(b []byte) (int, error) {
+	for i := range b {
+		b[i] = 0
+	}
+	return len(b), nil
+}
+
+type noSigner struct{}
+
+func (noSigner) Algorithm() cose.Algorithm {
+	return cose.AlgorithmES256
+}
+
+func (noSigner) Sign(_ io.Reader, digest []byte) ([]byte, error) {
+	return digest, nil
+}
+
+type noVerifier struct{}
+
+func (noVerifier) Algorithm() cose.Algorithm {
+	return cose.AlgorithmES256
+}
+
+func (noVerifier) Verify(_, _ []byte) error {
+	return nil
+}
+
+func BenchmarkSign1Message_MarshalCBOR(b *testing.B) {
+	msg := newSign1Message()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := msg.MarshalCBOR()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSign1Message_UnmarshalCBOR(b *testing.B) {
+	data, err := newSign1Message().MarshalCBOR()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var m cose.Sign1Message
+		err = m.UnmarshalCBOR(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSign1Message_Sign(b *testing.B) {
+	msg := newSign1Message()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		msg.Signature = nil
+		err := msg.Sign(zeroReader{}, nil, noSigner{})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSign1Message_Verify(b *testing.B) {
+	msg := newSign1Message()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := msg.Verify(nil, noVerifier{})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds benchmarks for `Sign1Message` methods. These benchmarks will be useful later one to do memory and cpu profiling.

These are the results on my Windows laptop (use only for reference):

```bash
goos: windows
goarch: amd64
pkg: github.com/veraison/go-cose
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
BenchmarkSign1Message_MarshalCBOR-12              666874              1791 ns/op             692 B/op         17 allocs/op
BenchmarkSign1Message_UnmarshalCBOR-12            368671              3303 ns/op            1592 B/op         28 allocs/op
BenchmarkSign1Message_Sign-12                     631834              1739 ns/op             668 B/op         16 allocs/op
BenchmarkSign1Message_Verify-12                   585108              1910 ns/op             668 B/op         16 allocs/op
```

For #52 