### PR TITLE
Guard against race conditions in RegisterAlgorithm

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"hash"
 	"strconv"
+	"sync"
 )
 
 // Algorithms supported by this library.
@@ -67,8 +68,10 @@ type extAlgorithm struct {
 	HashFunc func() hash.Hash
 }
 
-// extAlgorithms contains extended algorithms.
-var extAlgorithms map[Algorithm]extAlgorithm
+var (
+	extAlgorithms map[Algorithm]extAlgorithm
+	extMu         sync.RWMutex
+)
 
 // String returns the name of the algorithm
 func (a Algorithm) String() string {
@@ -90,7 +93,10 @@ func (a Algorithm) String() string {
 		// COSE.
 		return "EdDSA"
 	}
-	if alg, ok := extAlgorithms[a]; ok {
+	extMu.RLock()
+	alg, ok := extAlgorithms[a]
+	extMu.RUnlock()
+	if ok {
 		return alg.Name
 	}
 	return "unknown algorithm value " + strconv.Itoa(int(a))
@@ -118,7 +124,9 @@ func (a Algorithm) hashFunc() (crypto.Hash, bool) {
 func (a Algorithm) newHash() (hash.Hash, error) {
 	h, ok := a.hashFunc()
 	if !ok {
+		extMu.RLock()
 		alg, ok := extAlgorithms[a]
+		extMu.RUnlock()
 		if !ok {
 			return nil, ErrUnknownAlgorithm
 		}
@@ -165,6 +173,8 @@ func RegisterAlgorithm(alg Algorithm, name string, hash crypto.Hash, hashFunc fu
 	if _, ok := alg.hashFunc(); ok {
 		return ErrAlgorithmRegistered
 	}
+	extMu.Lock()
+	defer extMu.Unlock()
 	if _, ok := extAlgorithms[alg]; ok {
 		return ErrAlgorithmRegistered
 	}

--- a/algorithm.go
+++ b/algorithm.go
@@ -169,6 +169,7 @@ func (a Algorithm) computeHash(data []byte) ([]byte, error) {
 // set to 0, no hash is used for this algorithm.
 // The parameter `hashFunc` is preferred in the case that the hash algorithm is not
 // supported by the golang built-in crypto hashes.
+// It is safe for concurrent use by multiple goroutines.
 func RegisterAlgorithm(alg Algorithm, name string, hash crypto.Hash, hashFunc func() hash.Hash) error {
 	if _, ok := alg.hashFunc(); ok {
 		return ErrAlgorithmRegistered

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -234,6 +234,7 @@ func TestRegisterAlgorithm(t *testing.T) {
 	// Register algorithms concurrently to ensure testing on race mode catches races.
 	var wg sync.WaitGroup
 	wg.Add(3)
+
 	go func() {
 		defer wg.Done()
 		// register existing algorithm (should fail)

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -4,12 +4,15 @@ import (
 	"crypto"
 	"crypto/sha256"
 	"reflect"
+	"sync"
 	"testing"
 )
 
 // resetExtendedAlgorithm cleans up extended algorithms
 func resetExtendedAlgorithm() {
+	extMu.Lock()
 	extAlgorithms = nil
+	extMu.Unlock()
 }
 
 func TestAlgorithm_String(t *testing.T) {
@@ -228,19 +231,32 @@ func TestAlgorithm_computeHash(t *testing.T) {
 func TestRegisterAlgorithm(t *testing.T) {
 	defer resetExtendedAlgorithm()
 
-	// register existing algorithm (should fail)
-	if err := RegisterAlgorithm(AlgorithmES256, "ES256", crypto.SHA256, nil); err != ErrAlgorithmRegistered {
-		t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, ErrAlgorithmRegistered)
-	}
+	// Register algorithms concurrently to ensure testing on race mode catches races.
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		// register existing algorithm (should fail)
+		if err := RegisterAlgorithm(AlgorithmES256, "ES256", crypto.SHA256, nil); err != ErrAlgorithmRegistered {
+			t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, ErrAlgorithmRegistered)
+		}
+	}()
 
-	// register external algorithm
 	algFoo := Algorithm(-102)
-	if err := RegisterAlgorithm(algFoo, "foo", 0, nil); err != nil {
-		t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, false)
-	}
+	go func() {
+		defer wg.Done()
+		// register external algorithm
+		if err := RegisterAlgorithm(algFoo, "foo", 0, nil); err != nil {
+			t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, false)
+		}
+	}()
 
-	// double register external algorithm (should fail)
-	if err := RegisterAlgorithm(algFoo, "foo", 0, nil); err != ErrAlgorithmRegistered {
-		t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, ErrAlgorithmRegistered)
-	}
+	go func() {
+		defer wg.Done()
+		// double register external algorithm (should fail)
+		if err := RegisterAlgorithm(algFoo, "foo", 0, nil); err != ErrAlgorithmRegistered {
+			t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, ErrAlgorithmRegistered)
+		}
+	}()
+	wg.Wait()
 }

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -231,9 +231,29 @@ func TestAlgorithm_computeHash(t *testing.T) {
 func TestRegisterAlgorithm(t *testing.T) {
 	defer resetExtendedAlgorithm()
 
+	// register existing algorithm (should fail)
+	if err := RegisterAlgorithm(AlgorithmES256, "ES256", crypto.SHA256, nil); err != ErrAlgorithmRegistered {
+		t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, ErrAlgorithmRegistered)
+	}
+
+	algFoo := Algorithm(-102)
+	// register external algorithm
+	if err := RegisterAlgorithm(algFoo, "foo", 0, nil); err != nil {
+		t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, false)
+	}
+
+	// double register external algorithm (should fail)
+	if err := RegisterAlgorithm(algFoo, "foo", 0, nil); err != ErrAlgorithmRegistered {
+		t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, ErrAlgorithmRegistered)
+	}
+}
+
+func TestRegisterAlgorithm_Concurrent(t *testing.T) {
+	defer resetExtendedAlgorithm()
+
 	// Register algorithms concurrently to ensure testing on race mode catches races.
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(2)
 
 	go func() {
 		defer wg.Done()
@@ -242,21 +262,11 @@ func TestRegisterAlgorithm(t *testing.T) {
 			t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, ErrAlgorithmRegistered)
 		}
 	}()
-
-	algFoo := Algorithm(-102)
 	go func() {
 		defer wg.Done()
 		// register external algorithm
-		if err := RegisterAlgorithm(algFoo, "foo", 0, nil); err != nil {
+		if err := RegisterAlgorithm(Algorithm(-102), "foo", 0, nil); err != nil {
 			t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, false)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		// double register external algorithm (should fail)
-		if err := RegisterAlgorithm(algFoo, "foo", 0, nil); err != ErrAlgorithmRegistered {
-			t.Errorf("RegisterAlgorithm() error = %v, wantErr %v", err, ErrAlgorithmRegistered)
 		}
 	}()
 	wg.Wait()


### PR DESCRIPTION
NCC Group reported a race condition in `RegisterAlgorithm`:

> The registration is performed through a global map. There is no mutex protection:
concurrent accesses from several distinct threads (“goroutines”) may lead to adverse
effects, including multiple registration of an algorithm, apparent removal of an existing
registration, or a panic due to an out-of-bounds memory access
is expected to apply its own locking to ensure that no other thread may access the
library (including for merely verifying a signature) while any thread is performing a
registration; however, this aspect is entirely undocumented

This PR fix the race condition.

@SteveLasker @shizhMSFT