### PR TITLE
Fix integer range rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,7 @@ The supported algorithms can be extended at runtime by using [cose.RegisterAlgor
 
 ### Integer Ranges
 
-CBOR supports integers in the range:
-
-[-2<sup>64</sup>, -1] ∪ [0, 2<sup>64</sup> - 1]
+CBOR supports integers in the range [-2<sup>64</sup>, -1] ∪ [0, 2<sup>64</sup> - 1].
 
 This does not map onto a single Go integer type.
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,7 @@ The supported algorithms can be extended at runtime by using [cose.RegisterAlgor
 
 CBOR supports integers in the range:
 
-```text
 [-2<sup>64</sup>, -1] ∪ [0, 2<sup>64</sup> - 1]
-```
 
 This does not map onto a single Go integer type.
 


### PR DESCRIPTION
The integer range is not render correctly due to it being inside a code block.
Fix it by moving the range out of the code block.

Signed-off-by: qmuntal <qmuntaldiaz@microsoft.com>