### PR TITLE
Ensure IV and Partial IV are not both present

### DIFF
--- a/headers.go
+++ b/headers.go
@@ -173,7 +173,7 @@ func (h ProtectedHeader) ensureIV() error {
 	if _, ok := h[HeaderLabelPartialIV]; !ok {
 		return nil
 	}
-	return errors.New("The 'Initialization Vector' and 'Partial Initialization Vector' parameters must not both be present in the protected header")
+	return errors.New("the 'Initialization Vector' and 'Partial Initialization Vector' parameters must not both be present in the protected header")
 }
 
 // UnprotectedHeader contains parameters that are not cryptographically

--- a/headers_test.go
+++ b/headers_test.go
@@ -532,6 +532,14 @@ func TestUnprotectedHeader_MarshalCBOR(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "iv and partial iv present",
+			h: UnprotectedHeader{
+				HeaderLabelIV:        "foo",
+				HeaderLabelPartialIV: "bar",
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -629,6 +637,13 @@ func TestUnprotectedHeader_UnmarshalCBOR(t *testing.T) {
 			name: "int map key too large",
 			data: []byte{
 				0xa1, 0x3b, 0x83, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30,
+			},
+			wantErr: true,
+		},
+		{
+			name: "iv and partial iv present",
+			data: []byte{
+				0xa2, 0x5, 0x63, 0x66, 0x6f, 0x6f, 0x6, 0x63, 0x62, 0x61, 0x72,
 			},
 			wantErr: true,
 		},

--- a/headers_test.go
+++ b/headers_test.go
@@ -118,6 +118,14 @@ func TestProtectedHeader_MarshalCBOR(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "iv and partial iv present",
+			h: ProtectedHeader{
+				HeaderLabelIV:        "foo",
+				HeaderLabelPartialIV: "bar",
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -262,6 +270,13 @@ func TestProtectedHeader_UnmarshalCBOR(t *testing.T) {
 			name: "header as a byte array",
 			data: []byte{
 				0x80,
+			},
+			wantErr: true,
+		},
+		{
+			name: "iv and partial iv present",
+			data: []byte{
+				0x4b, 0xa2, 0x5, 0x63, 0x66, 0x6f, 0x6f, 0x6, 0x63, 0x62, 0x61, 0x72,
 			},
 			wantErr: true,
 		},

--- a/sign.go
+++ b/sign.go
@@ -73,11 +73,7 @@ func (s *Signature) MarshalCBOR() ([]byte, error) {
 	if len(s.Signature) == 0 {
 		return nil, ErrEmptySignature
 	}
-	protected, err := s.Headers.MarshalProtected()
-	if err != nil {
-		return nil, err
-	}
-	unprotected, err := s.Headers.MarshalUnprotected()
+	protected, unprotected, err := s.Headers.marshal()
 	if err != nil {
 		return nil, err
 	}
@@ -329,11 +325,7 @@ func (m *SignMessage) MarshalCBOR() ([]byte, error) {
 	if len(m.Signatures) == 0 {
 		return nil, ErrNoSignatures
 	}
-	protected, err := m.Headers.MarshalProtected()
-	if err != nil {
-		return nil, err
-	}
-	unprotected, err := m.Headers.MarshalUnprotected()
+	protected, unprotected, err := m.Headers.marshal()
 	if err != nil {
 		return nil, err
 	}

--- a/sign1.go
+++ b/sign1.go
@@ -58,11 +58,7 @@ func (m *Sign1Message) MarshalCBOR() ([]byte, error) {
 	if len(m.Signature) == 0 {
 		return nil, ErrEmptySignature
 	}
-	protected, err := m.Headers.MarshalProtected()
-	if err != nil {
-		return nil, err
-	}
-	unprotected, err := m.Headers.MarshalUnprotected()
+	protected, unprotected, err := m.Headers.marshal()
 	if err != nil {
 		return nil, err
 	}

--- a/sign1_test.go
+++ b/sign1_test.go
@@ -130,6 +130,40 @@ func TestSign1Message_MarshalCBOR(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "protected has IV and unprotected has PartialIV error",
+			m: &Sign1Message{
+				Headers: Headers{
+					Protected: ProtectedHeader{
+						HeaderLabelAlgorithm: AlgorithmES256,
+						HeaderLabelIV:        "",
+					},
+					Unprotected: UnprotectedHeader{
+						HeaderLabelPartialIV: "",
+					},
+				},
+				Payload:   []byte("foo"),
+				Signature: []byte("bar"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "protected has PartialIV and unprotected has IV error",
+			m: &Sign1Message{
+				Headers: Headers{
+					Protected: ProtectedHeader{
+						HeaderLabelAlgorithm: AlgorithmES256,
+						HeaderLabelPartialIV: "",
+					},
+					Unprotected: UnprotectedHeader{
+						HeaderLabelIV: "",
+					},
+				},
+				Payload:   []byte("foo"),
+				Signature: []byte("bar"),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -321,6 +355,30 @@ func TestSign1Message_UnmarshalCBOR(t *testing.T) {
 				0x40, 0xa0, // empty headers
 				0xf6,       // nil payload
 				0x81, 0x00, // signature
+			},
+			wantErr: true,
+		},
+		{
+			name: "protected has IV and unprotected has PartialIV",
+			data: []byte{
+				0xd2, // tag
+				0x84,
+				0x46, 0xa1, 0x5, 0x63, 0x66, 0x6f, 0x6f, // protected
+				0xa1, 0x6, 0x63, 0x62, 0x61, 0x72, // unprotected
+				0xf6,                   // payload
+				0x43, 0x62, 0x61, 0x72, // signature
+			},
+			wantErr: true,
+		},
+		{
+			name: "protected has PartialIV and unprotected has IV",
+			data: []byte{
+				0xd2, // tag
+				0x84,
+				0x46, 0xa1, 0x6, 0x63, 0x66, 0x6f, 0x6f, // protected
+				0xa1, 0x5, 0x63, 0x62, 0x61, 0x72, // unprotected
+				0xf6,                   // payload
+				0x43, 0x62, 0x61, 0x72, // signature
 			},
 			wantErr: true,
 		},

--- a/sign_test.go
+++ b/sign_test.go
@@ -102,6 +102,38 @@ func TestSignature_MarshalCBOR(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "protected has IV and unprotected has PartialIV error",
+			s: &Signature{
+				Headers: Headers{
+					Protected: ProtectedHeader{
+						HeaderLabelAlgorithm: AlgorithmES256,
+						HeaderLabelIV:        "",
+					},
+					Unprotected: UnprotectedHeader{
+						HeaderLabelPartialIV: "",
+					},
+				},
+				Signature: []byte("bar"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "protected has PartialIV and unprotected has IV error",
+			s: &Signature{
+				Headers: Headers{
+					Protected: ProtectedHeader{
+						HeaderLabelAlgorithm: AlgorithmES256,
+						HeaderLabelPartialIV: "",
+					},
+					Unprotected: UnprotectedHeader{
+						HeaderLabelIV: "",
+					},
+				},
+				Signature: []byte("bar"),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -224,6 +256,26 @@ func TestSignature_UnmarshalCBOR(t *testing.T) {
 				0x83,
 				0x40, 0xa0, // empty headers
 				0x81, 0x00, // signature
+			},
+			wantErr: true,
+		},
+		{
+			name: "protected has IV and unprotected has PartialIV",
+			data: []byte{
+				0x83,
+				0x46, 0xa1, 0x5, 0x63, 0x66, 0x6f, 0x6f, // protected
+				0xa1, 0x6, 0x63, 0x62, 0x61, 0x72, // unprotected
+				0x43, 0x62, 0x61, 0x72, // signature
+			},
+			wantErr: true,
+		},
+		{
+			name: "protected has PartialIV and unprotected has IV",
+			data: []byte{
+				0x83,
+				0x46, 0xa1, 0x6, 0x63, 0x66, 0x6f, 0x6f, // protected
+				0xa1, 0x5, 0x63, 0x62, 0x61, 0x72, // unprotected
+				0x43, 0x62, 0x61, 0x72, // signature
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
The NCC Group found this issue:

> Partial IV: The ‘Initialization Vector’ and ‘Partial Initialization Vector’ parameters
MUST NOT both be present in the same security layer. (Section 3.1)

> The go-cose library does not provide any explicit support for these parameters. A user is
free to set them within a message, but go-cose will not prevent usage that contradicts the
above requirement.

To meet this requirement, we should ensure that the IV and Partial IV are not both present in the protected header when marshaling and unmarshaling it. This PR does that.