### PR TITLE
Remove cose.Verify1 and update cose.Sign1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,15 @@ Construct a new COSE_Sign1 message, then sign it using ECDSA w/ SHA-512 and fina
 privateKey, _ := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 signer, _ := cose.NewSigner(cose.AlgorithmES512, privateKey)
 
-// create message to be signed
-msgToSign := cose.NewSign1Message()
-msgToSign.Payload = []byte("hello world")
-msgToSign.Headers.Protected.SetAlgorithm(cose.AlgorithmES512)
+// create message header
+headers := cose.Headers{
+    Protected: cose.ProtectedHeader{
+        cose.HeaderLabelAlgorithm: cose.AlgorithmES512,
+    },
+}
 
-// sign message
-_ = msgToSign.Sign(rand.Reader, nil, signer)
-
-// marshal message
-data, _ := msgToSign.MarshalCBOR()
+// sign and marshal message
+sig, _ := cose.Sign1(rand.Reader, signer, headers, []byte("hello world"), nil)
 ```
 
 Verify a raw COSE_Sign1 message. For example:

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -129,15 +129,19 @@ func FuzzSign1(f *testing.F) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		msg, err := cose.Sign1(rand.Reader, signer, hdr, payload, external)
+		msg := cose.Sign1Message{
+			Headers: cose.Headers{Protected: hdr},
+			Payload: payload,
+		}
+		err = msg.Sign(rand.Reader, external, signer)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = cose.Verify1(msg, external, verifier)
+		err = msg.Verify(external, verifier)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = cose.Verify1(msg, append(external, []byte{0}...), verifier)
+		err = msg.Verify(append(external, []byte{0}...), verifier)
 		if err == nil {
 			t.Fatal("verification error expected")
 		}

--- a/sign1.go
+++ b/sign1.go
@@ -227,30 +227,18 @@ func (m *Sign1Message) digestToBeSigned(alg Algorithm, external []byte) ([]byte,
 // This method is a wrapper of `Sign1Message.Sign()`.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
-func Sign1(rand io.Reader, signer Signer, protected ProtectedHeader, payload, external []byte) (*Sign1Message, error) {
-	if protected == nil {
-		protected = ProtectedHeader{}
-	}
-	msg := &Sign1Message{
-		Headers: Headers{
-			Protected:   protected,
-			Unprotected: UnprotectedHeader{},
-		},
+func Sign1(rand io.Reader, signer Signer, header Headers, payload []byte, external []byte) ([]byte, error) {
+	msg := Sign1Message{
+		Headers: header,
 		Payload: payload,
 	}
 	err := msg.Sign(rand, external, signer)
 	if err != nil {
 		return nil, err
 	}
-	return msg, nil
-}
-
-// Verify1 verifies a Sign1Message returning nil on success or a suitable error
-// if verification fails.
-//
-// This method is a wrapper of `Sign1Message.Verify()`.
-//
-// Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
-func Verify1(msg *Sign1Message, external []byte, verifier Verifier) error {
-	return msg.Verify(external, verifier)
+	sig, err := msg.MarshalCBOR()
+	if err != nil {
+		return nil, err
+	}
+	return sig, nil
 }


### PR DESCRIPTION
This PR implements what has been discussed at #64:

- Remove `cose.Verify1`. It is not clear which use case does it cover, as one normally wants to have the decoded payload, not only verify a message, but this function only does the later.
- Update `cose.Sign1` to also perform the encoding of the message and return the encoded bytes instead of a `Sign1Message` struct.

Closes #64

Signed-off-by: qmuntal <qmuntaldiaz@microsoft.com>