### PR TITLE
Enusre critical header contains valid labels

### DIFF
--- a/headers.go
+++ b/headers.go
@@ -160,7 +160,8 @@ func (h ProtectedHeader) ensureCritical() error {
 	for _, label := range labels {
 		switch label.(type) {
 		case int, int8, int16, int32, int64,
-			uint, uint8, uint16, uint32, uint64, string:
+			uint, uint8, uint16, uint32, uint64,
+			string:
 			// all ok.
 		default:
 			return fmt.Errorf("critical header label: require int / tstr type, got '%T': %v", label, label)

--- a/headers.go
+++ b/headers.go
@@ -158,6 +158,13 @@ func (h ProtectedHeader) ensureCritical() error {
 		return err
 	}
 	for _, label := range labels {
+		switch label.(type) {
+		case int, int8, int16, int32, int64,
+			uint, uint8, uint16, uint32, uint64, string:
+			// all ok.
+		default:
+			return fmt.Errorf("critical header label: require int / tstr type, got '%T': %v", label, label)
+		}
 		if _, ok := h[label]; !ok {
 			return fmt.Errorf("missing critical header: %v", label)
 		}

--- a/headers_test.go
+++ b/headers_test.go
@@ -104,6 +104,13 @@ func TestProtectedHeader_MarshalCBOR(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "critical header contains non-label element",
+			h: ProtectedHeader{
+				HeaderLabelCritical: []interface{}{[]uint8{}},
+			},
+			wantErr: true,
+		},
+		{
 			name: "duplicated key",
 			h: ProtectedHeader{
 				int8(42):  "foo",
@@ -235,6 +242,13 @@ func TestProtectedHeader_UnmarshalCBOR(t *testing.T) {
 			name: "missing header marked as critical",
 			data: []byte{
 				0x44, 0xa1, 0x02, 0x81, 0x03,
+			},
+			wantErr: true,
+		},
+		{
+			name: "critical header contains non-label element",
+			data: []byte{
+				0x44, 0xa1, 0x2, 0x81, 0x40,
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
Issue found by Trail of Bits during security review.

A protected header parameter containing a non-comparable element type, such a slice or a map, will produce a runtime panic while being encoded and decoded.

This is because the element is being used as map key to validate there are no missing critical headers, but non-comparable types can't be used as map keys, as per the [Go spec](https://go.dev/ref/spec#Map_types).

Investigating this issue, I found we are missing to validate that the critical header array only contains valid labels ([RFC 8152 Section 3.1](https://datatracker.ietf.org/doc/html/rfc8152#section-3.1)), which are restricted to integers and strings ([RFC 8152 Section 1.2](https://datatracker.ietf.org/doc/html/rfc8152#section-1.4)).

This PR adds a new validation step which ensures that the elements of the critical header are valid labels when encoding and decoding a protected header.

By doing that we also fix the original issue, as integers and strings are always comparable.

@yogeshbdeshpande @shizhMSFT @thomas-fossati

Signed-off-by: qmuntal <qmuntaldiaz@microsoft.com>