### PR TITLE
Validate generic headers

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -18,7 +18,7 @@ func ExampleSignMessage() {
 	// create a signature holder
 	sigHolder := cose.NewSignature()
 	sigHolder.Headers.Protected.SetAlgorithm(cose.AlgorithmES512)
-	sigHolder.Headers.Unprotected[cose.HeaderLabelKeyID] = 1
+	sigHolder.Headers.Unprotected[cose.HeaderLabelKeyID] = []byte("1")
 
 	// create message to be signed
 	msgToSign := cose.NewSignMessage()
@@ -84,7 +84,7 @@ func ExampleSign1Message() {
 	msgToSign := cose.NewSign1Message()
 	msgToSign.Payload = []byte("hello world")
 	msgToSign.Headers.Protected.SetAlgorithm(cose.AlgorithmES512)
-	msgToSign.Headers.Unprotected[cose.HeaderLabelKeyID] = 1
+	msgToSign.Headers.Unprotected[cose.HeaderLabelKeyID] = []byte("1")
 
 	// create a signer
 	privateKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
@@ -157,7 +157,7 @@ func ExampleSign1() {
 			cose.HeaderLabelAlgorithm: cose.AlgorithmES512,
 		},
 		Unprotected: cose.UnprotectedHeader{
-			cose.HeaderLabelKeyID: 1,
+			cose.HeaderLabelKeyID: []byte("1"),
 		},
 	}
 	sig, err := cose.Sign1(rand.Reader, signer, headers, []byte("hello world"), nil)

--- a/headers_test.go
+++ b/headers_test.go
@@ -45,25 +45,25 @@ func TestProtectedHeader_MarshalCBOR(t *testing.T) {
 		{
 			name: "various types of integer label",
 			h: ProtectedHeader{
-				uint(1):   0,
-				uint8(2):  0,
-				uint16(3): 0,
-				uint32(4): 0,
-				uint64(5): 0,
-				int(-1):   0,
-				int8(-2):  0,
-				int16(-3): 0,
-				int32(-4): 0,
-				int64(-5): 0,
+				uint(10):   0,
+				uint8(11):  0,
+				uint16(12): 0,
+				uint32(13): 0,
+				uint64(14): 0,
+				int(-1):    0,
+				int8(-2):   0,
+				int16(-3):  0,
+				int32(-4):  0,
+				int64(-5):  0,
 			},
 			want: []byte{
 				0x55, // bstr
 				0xaa, // map
-				0x01, 0x00,
-				0x02, 0x00,
-				0x03, 0x00,
-				0x04, 0x00,
-				0x05, 0x00,
+				0x0a, 0x00,
+				0x0b, 0x00,
+				0x0c, 0x00,
+				0x0d, 0x00,
+				0x0e, 0x00,
 				0x20, 0x00,
 				0x21, 0x00,
 				0x22, 0x00,
@@ -128,8 +128,8 @@ func TestProtectedHeader_MarshalCBOR(t *testing.T) {
 		{
 			name: "iv and partial iv present",
 			h: ProtectedHeader{
-				HeaderLabelIV:        "foo",
-				HeaderLabelPartialIV: "bar",
+				HeaderLabelIV:        []byte("foo"),
+				HeaderLabelPartialIV: []byte("bar"),
 			},
 			wantErr: true,
 		},
@@ -476,11 +476,11 @@ func TestUnprotectedHeader_MarshalCBOR(t *testing.T) {
 		{
 			name: "valid header",
 			h: UnprotectedHeader{
-				HeaderLabelKeyID: "foobar",
+				HeaderLabelAlgorithm: "foobar",
 			},
 			want: []byte{
 				0xa1,                                     // map
-				0x04,                                     // kid
+				0x01,                                     // alg
 				0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72, // foobar
 			},
 		},
@@ -497,24 +497,24 @@ func TestUnprotectedHeader_MarshalCBOR(t *testing.T) {
 		{
 			name: "various types of integer label",
 			h: UnprotectedHeader{
-				uint(1):   0,
-				uint8(2):  0,
-				uint16(3): 0,
-				uint32(4): 0,
-				uint64(5): 0,
-				int(-1):   0,
-				int8(-2):  0,
-				int16(-3): 0,
-				int32(-4): 0,
-				int64(-5): 0,
+				uint(10):   0,
+				uint8(11):  0,
+				uint16(12): 0,
+				uint32(13): 0,
+				uint64(14): 0,
+				int(-1):    0,
+				int8(-2):   0,
+				int16(-3):  0,
+				int32(-4):  0,
+				int64(-5):  0,
 			},
 			want: []byte{
 				0xaa, // map
-				0x01, 0x00,
-				0x02, 0x00,
-				0x03, 0x00,
-				0x04, 0x00,
-				0x05, 0x00,
+				0x0a, 0x00,
+				0x0b, 0x00,
+				0x0c, 0x00,
+				0x0d, 0x00,
+				0x0e, 0x00,
 				0x20, 0x00,
 				0x21, 0x00,
 				0x22, 0x00,
@@ -549,8 +549,8 @@ func TestUnprotectedHeader_MarshalCBOR(t *testing.T) {
 		{
 			name: "iv and partial iv present",
 			h: UnprotectedHeader{
-				HeaderLabelIV:        "foo",
-				HeaderLabelPartialIV: "bar",
+				HeaderLabelIV:        []byte("foo"),
+				HeaderLabelPartialIV: []byte("bar"),
 			},
 			wantErr: true,
 		},
@@ -587,11 +587,11 @@ func TestUnprotectedHeader_UnmarshalCBOR(t *testing.T) {
 			name: "valid header",
 			data: []byte{
 				0xa1,                                     // map
-				0x04,                                     // kid
+				0x01,                                     // alg
 				0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72, // foobar
 			},
 			want: UnprotectedHeader{
-				HeaderLabelKeyID: "foobar",
+				HeaderLabelAlgorithm: "foobar",
 			},
 		},
 		{
@@ -800,10 +800,10 @@ func TestHeaders_MarshalUnprotected(t *testing.T) {
 					HeaderLabelAlgorithm: AlgorithmES256,
 				},
 				Unprotected: UnprotectedHeader{
-					HeaderLabelKeyID: 42,
+					HeaderLabelContentType: 42,
 				},
 			},
-			want: []byte{0xa1, 0x04, 0x18, 0x2a},
+			want: []byte{0xa1, 0x03, 0x18, 0x2a},
 		},
 		{
 			name: "invalid protected header",
@@ -857,7 +857,7 @@ func TestHeaders_UnmarshalFromRaw(t *testing.T) {
 			name: "valid raw header",
 			h: Headers{
 				RawProtected:   []byte{0x43, 0xa1, 0x01, 0x26},
-				RawUnprotected: []byte{0xa1, 0x04, 0x18, 0x2a},
+				RawUnprotected: []byte{0xa1, 0x03, 0x18, 0x2a},
 			},
 			want: Headers{
 				RawProtected: []byte{0x43, 0xa1, 0x01, 0x26},
@@ -866,7 +866,7 @@ func TestHeaders_UnmarshalFromRaw(t *testing.T) {
 				},
 				RawUnprotected: []byte{0xa1, 0x04, 0x18, 0x2a},
 				Unprotected: UnprotectedHeader{
-					HeaderLabelKeyID: 42,
+					HeaderLabelContentType: 42,
 				},
 			},
 		},
@@ -877,9 +877,9 @@ func TestHeaders_UnmarshalFromRaw(t *testing.T) {
 				Protected: ProtectedHeader{
 					HeaderLabelAlgorithm: AlgorithmES512,
 				},
-				RawUnprotected: []byte{0xa1, 0x04, 0x18, 0x2a},
+				RawUnprotected: []byte{0xa1, 0x03, 0x18, 0x2a},
 				Unprotected: UnprotectedHeader{
-					HeaderLabelKeyID: 43,
+					HeaderLabelContentType: 43,
 				},
 			},
 			want: Headers{

--- a/sign1_test.go
+++ b/sign1_test.go
@@ -23,7 +23,7 @@ func TestSign1Message_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelContentType: 42,
 					},
 				},
 				Payload:   []byte("foo"),
@@ -33,7 +33,7 @@ func TestSign1Message_MarshalCBOR(t *testing.T) {
 				0xd2, // tag
 				0x84,
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0x43, 0x66, 0x6f, 0x6f, // payload
 				0x43, 0x62, 0x61, 0x72, // signature
 			},
@@ -51,7 +51,7 @@ func TestSign1Message_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelContentType: 42,
 					},
 				},
 				Payload:   nil,
@@ -61,7 +61,7 @@ func TestSign1Message_MarshalCBOR(t *testing.T) {
 				0xd2, // tag
 				0x84,
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0xf6,                   // payload
 				0x43, 0x62, 0x61, 0x72, // signature
 			},
@@ -74,7 +74,7 @@ func TestSign1Message_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload:   []byte("foo"),
@@ -90,7 +90,7 @@ func TestSign1Message_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload:   nil,
@@ -106,7 +106,7 @@ func TestSign1Message_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: make(chan bool),
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload:   []byte("foo"),
@@ -122,7 +122,7 @@ func TestSign1Message_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: make(chan bool),
+						"foo": make(chan bool),
 					},
 				},
 				Payload:   []byte("foo"),
@@ -136,10 +136,10 @@ func TestSign1Message_MarshalCBOR(t *testing.T) {
 				Headers: Headers{
 					Protected: ProtectedHeader{
 						HeaderLabelAlgorithm: AlgorithmES256,
-						HeaderLabelIV:        "",
+						HeaderLabelIV:        []byte(""),
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelPartialIV: "",
+						HeaderLabelPartialIV: []byte(""),
 					},
 				},
 				Payload:   []byte("foo"),
@@ -153,10 +153,10 @@ func TestSign1Message_MarshalCBOR(t *testing.T) {
 				Headers: Headers{
 					Protected: ProtectedHeader{
 						HeaderLabelAlgorithm: AlgorithmES256,
-						HeaderLabelPartialIV: "",
+						HeaderLabelPartialIV: []byte(""),
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelIV: "",
+						HeaderLabelIV: []byte(""),
 					},
 				},
 				Payload:   []byte("foo"),
@@ -202,7 +202,7 @@ func TestSign1Message_UnmarshalCBOR(t *testing.T) {
 				0xd2, // tag
 				0x84,
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0x43, 0x66, 0x6f, 0x6f, // payload
 				0x43, 0x62, 0x61, 0x72, // signature
 			},
@@ -212,9 +212,9 @@ func TestSign1Message_UnmarshalCBOR(t *testing.T) {
 					Protected: ProtectedHeader{
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
-					RawUnprotected: []byte{0xa1, 0x04, 0x18, 0x2a},
+					RawUnprotected: []byte{0xa1, 0x03, 0x18, 0x2a},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: int64(42),
+						HeaderLabelContentType: int64(42),
 					},
 				},
 				Payload:   []byte("foo"),
@@ -227,7 +227,7 @@ func TestSign1Message_UnmarshalCBOR(t *testing.T) {
 				0xd2, // tag
 				0x84,
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0xf6,                   // payload
 				0x43, 0x62, 0x61, 0x72, // signature
 			},
@@ -237,9 +237,9 @@ func TestSign1Message_UnmarshalCBOR(t *testing.T) {
 					Protected: ProtectedHeader{
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
-					RawUnprotected: []byte{0xa1, 0x04, 0x18, 0x2a},
+					RawUnprotected: []byte{0xa1, 0x03, 0x18, 0x2a},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: int64(42),
+						HeaderLabelContentType: int64(42),
 					},
 				},
 				Payload:   nil,
@@ -428,7 +428,7 @@ func TestSign1Message_Sign(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload: []byte("hello world"),
@@ -444,7 +444,7 @@ func TestSign1Message_Sign(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload: []byte("hello world"),
@@ -460,7 +460,7 @@ func TestSign1Message_Sign(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload: []byte("hello world"),
@@ -476,7 +476,7 @@ func TestSign1Message_Sign(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload: []byte("hello world"),
@@ -596,7 +596,7 @@ func TestSign1Message_Sign_Internal(t *testing.T) {
 						HeaderLabelAlgorithm: algorithmMock,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload: []byte("hello world"),
@@ -618,7 +618,7 @@ func TestSign1Message_Sign_Internal(t *testing.T) {
 						HeaderLabelAlgorithm: algorithmMock,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload: []byte("hello world"),
@@ -640,7 +640,7 @@ func TestSign1Message_Sign_Internal(t *testing.T) {
 						HeaderLabelAlgorithm: algorithmMock,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload: []byte("hello world"),
@@ -799,7 +799,7 @@ func TestSign1Message_Verify(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload: []byte("hello world"),

--- a/sign_test.go
+++ b/sign_test.go
@@ -25,7 +25,7 @@ func TestSignature_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelContentType: 42,
 					},
 				},
 				Signature: []byte("bar"),
@@ -33,7 +33,7 @@ func TestSignature_MarshalCBOR(t *testing.T) {
 			want: []byte{
 				0x83,                   // array of size 3
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0x43, 0x62, 0x61, 0x72, // signature
 			},
 		},
@@ -50,7 +50,7 @@ func TestSignature_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelContentType: 42,
 					},
 				},
 				Signature: nil,
@@ -65,7 +65,7 @@ func TestSignature_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelContentType: 42,
 					},
 				},
 				Signature: []byte{},
@@ -80,7 +80,7 @@ func TestSignature_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: make(chan bool),
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelContentType: 42,
 					},
 				},
 				Signature: []byte("bar"),
@@ -95,7 +95,7 @@ func TestSignature_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: make(chan bool),
+						"foo": make(chan bool),
 					},
 				},
 				Signature: []byte("bar"),
@@ -108,10 +108,10 @@ func TestSignature_MarshalCBOR(t *testing.T) {
 				Headers: Headers{
 					Protected: ProtectedHeader{
 						HeaderLabelAlgorithm: AlgorithmES256,
-						HeaderLabelIV:        "",
+						HeaderLabelIV:        []byte(""),
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelPartialIV: "",
+						HeaderLabelPartialIV: []byte(""),
 					},
 				},
 				Signature: []byte("bar"),
@@ -124,10 +124,10 @@ func TestSignature_MarshalCBOR(t *testing.T) {
 				Headers: Headers{
 					Protected: ProtectedHeader{
 						HeaderLabelAlgorithm: AlgorithmES256,
-						HeaderLabelPartialIV: "",
+						HeaderLabelPartialIV: []byte(""),
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelIV: "",
+						HeaderLabelIV: []byte(""),
 					},
 				},
 				Signature: []byte("bar"),
@@ -171,7 +171,7 @@ func TestSignature_UnmarshalCBOR(t *testing.T) {
 			data: []byte{
 				0x83,
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0x43, 0x62, 0x61, 0x72, // signature
 			},
 			want: Signature{
@@ -180,9 +180,9 @@ func TestSignature_UnmarshalCBOR(t *testing.T) {
 					Protected: ProtectedHeader{
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
-					RawUnprotected: []byte{0xa1, 0x04, 0x18, 0x2a},
+					RawUnprotected: []byte{0xa1, 0x03, 0x18, 0x2a},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: int64(42),
+						HeaderLabelContentType: int64(42),
 					},
 				},
 				Signature: []byte("bar"),
@@ -329,7 +329,7 @@ func TestSignature_Sign(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			},
@@ -352,7 +352,7 @@ func TestSignature_Sign(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			},
@@ -375,7 +375,7 @@ func TestSignature_Sign(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			},
@@ -398,7 +398,7 @@ func TestSignature_Sign(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			},
@@ -545,7 +545,7 @@ func TestSignature_Sign(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			},
@@ -567,7 +567,7 @@ func TestSignature_Sign(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			},
@@ -589,7 +589,7 @@ func TestSignature_Sign(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			},
@@ -641,7 +641,7 @@ func TestSignature_Sign_Internal(t *testing.T) {
 						HeaderLabelAlgorithm: algorithmMock,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			},
@@ -665,7 +665,7 @@ func TestSignature_Sign_Internal(t *testing.T) {
 						HeaderLabelAlgorithm: algorithmMock,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			},
@@ -689,7 +689,7 @@ func TestSignature_Sign_Internal(t *testing.T) {
 						HeaderLabelAlgorithm: algorithmMock,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			},
@@ -713,7 +713,7 @@ func TestSignature_Sign_Internal(t *testing.T) {
 						HeaderLabelAlgorithm: algorithmMock,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			},
@@ -1029,7 +1029,7 @@ func TestSignature_Verify(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 			}
@@ -1077,7 +1077,7 @@ func TestSignMessage_MarshalCBOR(t *testing.T) {
 								HeaderLabelAlgorithm: AlgorithmES256,
 							},
 							Unprotected: UnprotectedHeader{
-								HeaderLabelKeyID: 42,
+								HeaderLabelContentType: 42,
 							},
 						},
 						Signature: []byte("foo"),
@@ -1106,7 +1106,7 @@ func TestSignMessage_MarshalCBOR(t *testing.T) {
 				0x82,                   // signatures
 				0x83,                   // signature 0
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0x43, 0x66, 0x6f, 0x6f, // signature
 				0x83,                         // signature 1
 				0x44, 0xa1, 0x01, 0x38, 0x26, // protected
@@ -1133,7 +1133,7 @@ func TestSignMessage_MarshalCBOR(t *testing.T) {
 								HeaderLabelAlgorithm: AlgorithmES256,
 							},
 							Unprotected: UnprotectedHeader{
-								HeaderLabelKeyID: 42,
+								HeaderLabelContentType: 42,
 							},
 						},
 						Signature: []byte("foo"),
@@ -1154,7 +1154,7 @@ func TestSignMessage_MarshalCBOR(t *testing.T) {
 				0x81,                   // signatures
 				0x83,                   // signature 0
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0x43, 0x66, 0x6f, 0x6f, // signature
 			},
 		},
@@ -1214,7 +1214,7 @@ func TestSignMessage_MarshalCBOR(t *testing.T) {
 								HeaderLabelAlgorithm: AlgorithmES256,
 							},
 							Unprotected: UnprotectedHeader{
-								HeaderLabelKeyID: 42,
+								HeaderLabelContentType: 42,
 							},
 						},
 						Signature: []byte("foo"),
@@ -1234,7 +1234,7 @@ func TestSignMessage_MarshalCBOR(t *testing.T) {
 				0x81,                   // signatures
 				0x83,                   // signature 0
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0x43, 0x66, 0x6f, 0x6f, // signature
 			},
 		},
@@ -1246,7 +1246,7 @@ func TestSignMessage_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: make(chan bool),
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: 42,
+						HeaderLabelKeyID: []byte("42"),
 					},
 				},
 				Payload: []byte("foo"),
@@ -1271,7 +1271,7 @@ func TestSignMessage_MarshalCBOR(t *testing.T) {
 						HeaderLabelAlgorithm: AlgorithmES256,
 					},
 					Unprotected: UnprotectedHeader{
-						HeaderLabelKeyID: make(chan bool),
+						"foo": make(chan bool),
 					},
 				},
 				Payload: []byte("foo"),
@@ -1339,7 +1339,7 @@ func TestSignMessage_UnmarshalCBOR(t *testing.T) {
 				0x82,                   // signatures
 				0x83,                   // signature 0
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0x43, 0x66, 0x6f, 0x6f, // signature
 				0x83,                         // signature 1
 				0x44, 0xa1, 0x01, 0x38, 0x26, // protected
@@ -1373,9 +1373,9 @@ func TestSignMessage_UnmarshalCBOR(t *testing.T) {
 							Protected: ProtectedHeader{
 								HeaderLabelAlgorithm: AlgorithmES256,
 							},
-							RawUnprotected: []byte{0xa1, 0x04, 0x18, 0x2a},
+							RawUnprotected: []byte{0xa1, 0x03, 0x18, 0x2a},
 							Unprotected: UnprotectedHeader{
-								HeaderLabelKeyID: int64(42),
+								HeaderLabelContentType: int64(42),
 							},
 						},
 						Signature: []byte("foo"),
@@ -1410,7 +1410,7 @@ func TestSignMessage_UnmarshalCBOR(t *testing.T) {
 				0x81,                   // signatures
 				0x83,                   // signature 0
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0x43, 0x66, 0x6f, 0x6f, // signature
 			},
 			want: SignMessage{
@@ -1440,9 +1440,9 @@ func TestSignMessage_UnmarshalCBOR(t *testing.T) {
 							Protected: ProtectedHeader{
 								HeaderLabelAlgorithm: AlgorithmES256,
 							},
-							RawUnprotected: []byte{0xa1, 0x04, 0x18, 0x2a},
+							RawUnprotected: []byte{0xa1, 0x03, 0x18, 0x2a},
 							Unprotected: UnprotectedHeader{
-								HeaderLabelKeyID: int64(42),
+								HeaderLabelContentType: int64(42),
 							},
 						},
 						Signature: []byte("foo"),
@@ -1465,7 +1465,7 @@ func TestSignMessage_UnmarshalCBOR(t *testing.T) {
 				0x81,                   // signatures
 				0x83,                   // signature 0
 				0x43, 0xa1, 0x01, 0x26, // protected
-				0xa1, 0x04, 0x18, 0x2a, // unprotected
+				0xa1, 0x03, 0x18, 0x2a, // unprotected
 				0x43, 0x66, 0x6f, 0x6f, // signature
 			},
 			want: SignMessage{
@@ -1495,9 +1495,9 @@ func TestSignMessage_UnmarshalCBOR(t *testing.T) {
 							Protected: ProtectedHeader{
 								HeaderLabelAlgorithm: AlgorithmES256,
 							},
-							RawUnprotected: []byte{0xa1, 0x04, 0x18, 0x2a},
+							RawUnprotected: []byte{0xa1, 0x03, 0x18, 0x2a},
 							Unprotected: UnprotectedHeader{
-								HeaderLabelKeyID: int64(42),
+								HeaderLabelContentType: int64(42),
 							},
 						},
 						Signature: []byte("foo"),
@@ -1699,7 +1699,7 @@ func TestSignMessage_Sign(t *testing.T) {
 								HeaderLabelAlgorithm: AlgorithmES256,
 							},
 							Unprotected: UnprotectedHeader{
-								HeaderLabelKeyID: 42,
+								HeaderLabelKeyID: []byte("42"),
 							},
 						},
 					},
@@ -1734,7 +1734,7 @@ func TestSignMessage_Sign(t *testing.T) {
 								HeaderLabelAlgorithm: AlgorithmES256,
 							},
 							Unprotected: UnprotectedHeader{
-								HeaderLabelKeyID: 42,
+								HeaderLabelKeyID: []byte("42"),
 							},
 						},
 					},
@@ -1769,7 +1769,7 @@ func TestSignMessage_Sign(t *testing.T) {
 								HeaderLabelAlgorithm: AlgorithmES256,
 							},
 							Unprotected: UnprotectedHeader{
-								HeaderLabelKeyID: 42,
+								HeaderLabelKeyID: []byte("42"),
 							},
 						},
 					},
@@ -1804,7 +1804,7 @@ func TestSignMessage_Sign(t *testing.T) {
 								HeaderLabelAlgorithm: AlgorithmES256,
 							},
 							Unprotected: UnprotectedHeader{
-								HeaderLabelKeyID: 42,
+								HeaderLabelKeyID: []byte("42"),
 							},
 						},
 					},
@@ -2121,7 +2121,7 @@ func TestSignMessage_Verify(t *testing.T) {
 								HeaderLabelAlgorithm: AlgorithmES256,
 							},
 							Unprotected: UnprotectedHeader{
-								HeaderLabelKeyID: 42,
+								HeaderLabelKeyID: []byte("42"),
 							},
 						},
 					},
@@ -2170,7 +2170,7 @@ func TestSignMessage_Verify(t *testing.T) {
 							HeaderLabelAlgorithm: AlgorithmES256,
 						},
 						Unprotected: UnprotectedHeader{
-							HeaderLabelKeyID: 42,
+							HeaderLabelKeyID: []byte("42"),
 						},
 					},
 				},


### PR DESCRIPTION
This PR validates that the [Common COSE Headers Parameters](https://datatracker.ietf.org/doc/html/rfc8152#section-3.1) have to correct type.

The change has been quite disruptive for our test cases, because we were using headers containing invalid parameters. Most of the test changes are related to fixing those tests.

This PR does not validate counter signature nor x509 common parameters, as go-cose currently does not expose the CBOR types which are contained in those parameters.

Fix #82

Signed-off-by: qmuntal <qmuntaldiaz@microsoft.com>