### PR TITLE
Increase headers type validation coverage

### DIFF
--- a/headers_test.go
+++ b/headers_test.go
@@ -134,9 +134,30 @@ func TestProtectedHeader_MarshalCBOR(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "invalid content type value",
+			name: "content type is string",
 			h: ProtectedHeader{
 				HeaderLabelContentType: []byte("foo"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "content type is negative int8",
+			h: ProtectedHeader{
+				HeaderLabelContentType: int8(-1),
+			},
+			wantErr: true,
+		},
+		{
+			name: "content type is negative int16",
+			h: ProtectedHeader{
+				HeaderLabelContentType: int16(-1),
+			},
+			wantErr: true,
+		},
+		{
+			name: "content type is negative int32",
+			h: ProtectedHeader{
+				HeaderLabelContentType: int32(-1),
 			},
 			wantErr: true,
 		},

--- a/headers_test.go
+++ b/headers_test.go
@@ -133,6 +133,13 @@ func TestProtectedHeader_MarshalCBOR(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "invalid content type value",
+			h: ProtectedHeader{
+				HeaderLabelContentType: []byte("foo"),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -800,7 +807,7 @@ func TestHeaders_MarshalUnprotected(t *testing.T) {
 					HeaderLabelAlgorithm: AlgorithmES256,
 				},
 				Unprotected: UnprotectedHeader{
-					HeaderLabelContentType: 42,
+					HeaderLabelContentType: uint8(42),
 				},
 			},
 			want: []byte{0xa1, 0x03, 0x18, 0x2a},
@@ -866,7 +873,7 @@ func TestHeaders_UnmarshalFromRaw(t *testing.T) {
 				},
 				RawUnprotected: []byte{0xa1, 0x04, 0x18, 0x2a},
 				Unprotected: UnprotectedHeader{
-					HeaderLabelContentType: 42,
+					HeaderLabelContentType: int8(42),
 				},
 			},
 		},
@@ -879,7 +886,7 @@ func TestHeaders_UnmarshalFromRaw(t *testing.T) {
 				},
 				RawUnprotected: []byte{0xa1, 0x03, 0x18, 0x2a},
 				Unprotected: UnprotectedHeader{
-					HeaderLabelContentType: 43,
+					HeaderLabelContentType: int16(43),
 				},
 			},
 			want: Headers{


### PR DESCRIPTION
#87 was merged without rerunning code coverage PR check added in #84, and now codecov is complaining because `main` does not meet the 89% coverage threshold. Let's fix it.

@SteveLasker @thomas-fossati @yogeshbdeshpande 