### PR TITLE
refactor!: accept message content instead of digest for sign and verify

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -4,7 +4,6 @@ import (
 	"crypto"
 	"hash"
 	"strconv"
-	"sync"
 )
 
 // Algorithms supported by this library.
@@ -43,35 +42,12 @@ const (
 // Algorithm represents an IANA algorithm entry in the COSE Algorithms registry.
 // Algorithms with string values are not supported.
 //
-// See Also
+// # See Also
 //
 // COSE Algorithms: https://www.iana.org/assignments/cose/cose.xhtml#algorithms
 //
 // RFC 8152 16.4: https://datatracker.ietf.org/doc/html/rfc8152#section-16.4
 type Algorithm int64
-
-// extAlgorithm describes an extended algorithm, which is not implemented this
-// library.
-type extAlgorithm struct {
-	// Name of the algorithm.
-	Name string
-
-	// Hash is the hash algorithm associated with the algorithm.
-	// If HashFunc is present, Hash is ignored.
-	// If HashFunc is not present and Hash is set to 0, no hash is used.
-	Hash crypto.Hash
-
-	// HashFunc is the hash algorithm associated with the algorithm.
-	// HashFunc is preferred in the case that the hash algorithm is not
-	// supported by the golang built-in crypto hashes.
-	// For regular scenarios, use Hash instead.
-	HashFunc func() hash.Hash
-}
-
-var (
-	extAlgorithms map[Algorithm]extAlgorithm
-	extMu         sync.RWMutex
-)
 
 // String returns the name of the algorithm
 func (a Algorithm) String() string {
@@ -92,14 +68,9 @@ func (a Algorithm) String() string {
 		// As stated in RFC 8152 8.2, only the pure EdDSA version is used for
 		// COSE.
 		return "EdDSA"
+	default:
+		return "unknown algorithm value " + strconv.Itoa(int(a))
 	}
-	extMu.RLock()
-	alg, ok := extAlgorithms[a]
-	extMu.RUnlock()
-	if ok {
-		return alg.Name
-	}
-	return "unknown algorithm value " + strconv.Itoa(int(a))
 }
 
 // hashFunc returns the hash associated with the algorithm supported by this
@@ -124,16 +95,7 @@ func (a Algorithm) hashFunc() (crypto.Hash, bool) {
 func (a Algorithm) newHash() (hash.Hash, error) {
 	h, ok := a.hashFunc()
 	if !ok {
-		extMu.RLock()
-		alg, ok := extAlgorithms[a]
-		extMu.RUnlock()
-		if !ok {
-			return nil, ErrUnknownAlgorithm
-		}
-		if alg.HashFunc != nil {
-			return alg.HashFunc(), nil
-		}
-		h = alg.Hash
+		return nil, ErrUnknownAlgorithm
 	}
 	if h == 0 {
 		// no hash required
@@ -159,33 +121,4 @@ func (a Algorithm) computeHash(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	return h.Sum(nil), nil
-}
-
-// RegisterAlgorithm provides extensibility for the COSE library to support
-// private algorithms or algorithms not yet registered in IANA.
-// The existing algorithms cannot be re-registered.
-// The parameter `hash` is the hash algorithm associated with the algorithm. If
-// hashFunc is present, hash is ignored. If hashFunc is not present and hash is
-// set to 0, no hash is used for this algorithm.
-// The parameter `hashFunc` is preferred in the case that the hash algorithm is not
-// supported by the golang built-in crypto hashes.
-// It is safe for concurrent use by multiple goroutines.
-func RegisterAlgorithm(alg Algorithm, name string, hash crypto.Hash, hashFunc func() hash.Hash) error {
-	if _, ok := alg.hashFunc(); ok {
-		return ErrAlgorithmRegistered
-	}
-	extMu.Lock()
-	defer extMu.Unlock()
-	if _, ok := extAlgorithms[alg]; ok {
-		return ErrAlgorithmRegistered
-	}
-	if extAlgorithms == nil {
-		extAlgorithms = make(map[Algorithm]extAlgorithm)
-	}
-	extAlgorithms[alg] = extAlgorithm{
-		Name:     name,
-		Hash:     hash,
-		HashFunc: hashFunc,
-	}
-	return nil
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -14,7 +14,7 @@ func newSign1Message() *cose.Sign1Message {
 				cose.HeaderLabelAlgorithm: cose.AlgorithmES256,
 			},
 			Unprotected: cose.UnprotectedHeader{
-				cose.HeaderLabelKeyID: 1,
+				cose.HeaderLabelKeyID: []byte{0x01},
 			},
 		},
 		Payload:   make([]byte, 100),

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -151,9 +151,6 @@ func (ev *ecdsaVerifier) Verify(content []byte, signature []byte) error {
 	// compute digest
 	digest, err := ev.alg.computeHash(content)
 	if err != nil {
-		if err != ErrUnavailableHashFunc {
-			return ErrVerification
-		}
 		return err
 	}
 

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -47,12 +47,16 @@ func (es *ecdsaKeySigner) Algorithm() Algorithm {
 	return es.alg
 }
 
-// Sign signs digest with the private key using entropy from rand.
+// Sign signs message content with the private key using entropy from rand.
 // The resulting signature should follow RFC 8152 section 8.1,
 // although it does not follow the recommendation of being deterministic.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8.1
-func (es *ecdsaKeySigner) Sign(rand io.Reader, digest []byte) ([]byte, error) {
+func (es *ecdsaKeySigner) Sign(rand io.Reader, content []byte) ([]byte, error) {
+	digest, err := es.alg.computeHash(content)
+	if err != nil {
+		return nil, err
+	}
 	r, s, err := ecdsa.Sign(rand, es.key, digest)
 	if err != nil {
 		return nil, err
@@ -72,11 +76,16 @@ func (es *ecdsaCryptoSigner) Algorithm() Algorithm {
 	return es.alg
 }
 
-// Sign signs digest with the private key, possibly using entropy from rand.
+// Sign signs message content with the private key, possibly using entropy from
+// rand.
 // The resulting signature should follow RFC 8152 section 8.1.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8.1
-func (es *ecdsaCryptoSigner) Sign(rand io.Reader, digest []byte) ([]byte, error) {
+func (es *ecdsaCryptoSigner) Sign(rand io.Reader, content []byte) ([]byte, error) {
+	digest, err := es.alg.computeHash(content)
+	if err != nil {
+		return nil, err
+	}
 	sigASN1, err := es.signer.Sign(rand, digest, nil)
 	if err != nil {
 		return nil, err
@@ -133,14 +142,19 @@ func (ev *ecdsaVerifier) Algorithm() Algorithm {
 	return ev.alg
 }
 
-// Verify verifies digest with the public key, returning nil for success.
+// Verify verifies message content with the public key, returning nil for
+// success.
 // Otherwise, it returns ErrVerification.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8.1
-func (ev *ecdsaVerifier) Verify(digest []byte, signature []byte) error {
-	// verify digest size
-	if h, ok := ev.alg.hashFunc(); !ok || h.Size() != len(digest) {
-		return ErrVerification
+func (ev *ecdsaVerifier) Verify(content []byte, signature []byte) error {
+	// compute digest
+	digest, err := ev.alg.computeHash(content)
+	if err != nil {
+		if err != ErrUnavailableHashFunc {
+			return ErrVerification
+		}
+		return err
 	}
 
 	// verify signature

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -211,11 +211,11 @@ func testSignVerify(t *testing.T, alg Algorithm, key crypto.Signer, isCryptoSign
 
 	// sign / verify round trip
 	// see also conformance_test.go for strict tests.
-	digest, err := alg.computeHash([]byte("hello world"))
+	content := []byte("hello world")
 	if err != nil {
 		t.Fatalf("Algorithm.computeHash() error = %v", err)
 	}
-	sig, err := signer.Sign(rand.Reader, digest)
+	sig, err := signer.Sign(rand.Reader, content)
 	if err != nil {
 		t.Fatalf("Sign() error = %v", err)
 	}
@@ -224,7 +224,7 @@ func testSignVerify(t *testing.T, alg Algorithm, key crypto.Signer, isCryptoSign
 	if err != nil {
 		t.Fatalf("NewVerifier() error = %v", err)
 	}
-	if err := verifier.Verify(digest, sig); err != nil {
+	if err := verifier.Verify(content, sig); err != nil {
 		t.Fatalf("Verifier.Verify() error = %v", err)
 	}
 }
@@ -235,7 +235,7 @@ func Test_ecdsaVerifier_Verify_Success(t *testing.T) {
 	key := generateTestECDSAKey(t)
 
 	// generate a valid signature
-	digest, sig := signTestData(t, alg, key)
+	content, sig := signTestData(t, alg, key)
 
 	// set up verifier
 	verifier, err := NewVerifier(alg, key.Public())
@@ -250,7 +250,7 @@ func Test_ecdsaVerifier_Verify_Success(t *testing.T) {
 	}
 
 	// verify round trip
-	if err := verifier.Verify(digest, sig); err != nil {
+	if err := verifier.Verify(content, sig); err != nil {
 		t.Fatalf("ecdsaVerifier.Verify() error = %v", err)
 	}
 }
@@ -261,7 +261,7 @@ func Test_ecdsaVerifier_Verify_AlgorithmMismatch(t *testing.T) {
 	key := generateTestECDSAKey(t)
 
 	// generate a valid signature
-	digest, sig := signTestData(t, alg, key)
+	content, sig := signTestData(t, alg, key)
 
 	// set up verifier with a different algorithm
 	verifier := &ecdsaVerifier{
@@ -270,7 +270,7 @@ func Test_ecdsaVerifier_Verify_AlgorithmMismatch(t *testing.T) {
 	}
 
 	// verification should fail on algorithm mismatch
-	if err := verifier.Verify(digest, sig); err != ErrVerification {
+	if err := verifier.Verify(content, sig); err != ErrVerification {
 		t.Fatalf("ecdsaVerifier.Verify() error = %v, wantErr %v", err, ErrVerification)
 	}
 }
@@ -281,7 +281,7 @@ func Test_ecdsaVerifier_Verify_KeyMismatch(t *testing.T) {
 	key := generateTestECDSAKey(t)
 
 	// generate a valid signature
-	digest, sig := signTestData(t, alg, key)
+	content, sig := signTestData(t, alg, key)
 
 	// set up verifier with a different key / new key
 	key = generateTestECDSAKey(t)
@@ -291,7 +291,7 @@ func Test_ecdsaVerifier_Verify_KeyMismatch(t *testing.T) {
 	}
 
 	// verification should fail on key mismatch
-	if err := verifier.Verify(digest, sig); err != ErrVerification {
+	if err := verifier.Verify(content, sig); err != ErrVerification {
 		t.Fatalf("ecdsaVerifier.Verify() error = %v, wantErr %v", err, ErrVerification)
 	}
 }
@@ -302,7 +302,7 @@ func Test_ecdsaVerifier_Verify_InvalidSignature(t *testing.T) {
 	key := generateTestECDSAKey(t)
 
 	// generate a valid signature with a tampered one
-	digest, sig := signTestData(t, alg, key)
+	content, sig := signTestData(t, alg, key)
 	tamperedSig := make([]byte, len(sig))
 	copy(tamperedSig, sig)
 	tamperedSig[0]++
@@ -341,7 +341,7 @@ func Test_ecdsaVerifier_Verify_InvalidSignature(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := verifier.Verify(digest, tt.signature); err != ErrVerification {
+			if err := verifier.Verify(content, tt.signature); err != ErrVerification {
 				t.Errorf("ecdsaVerifier.Verify() error = %v, wantErr %v", err, ErrVerification)
 			}
 		})

--- a/ed25519.go
+++ b/ed25519.go
@@ -16,14 +16,15 @@ func (es *ed25519Signer) Algorithm() Algorithm {
 	return AlgorithmEd25519
 }
 
-// Sign signs digest with the private key, possibly using entropy from rand.
+// Sign signs message content with the private key, possibly using entropy from
+// rand.
 // The resulting signature should follow RFC 8152 section 8.2.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8.2
-func (es *ed25519Signer) Sign(rand io.Reader, digest []byte) ([]byte, error) {
+func (es *ed25519Signer) Sign(rand io.Reader, content []byte) ([]byte, error) {
 	// crypto.Hash(0) must be passed as an option.
 	// Reference: https://pkg.go.dev/crypto/ed25519#PrivateKey.Sign
-	return es.key.Sign(rand, digest, crypto.Hash(0))
+	return es.key.Sign(rand, content, crypto.Hash(0))
 }
 
 // ed25519Verifier is a Pure EdDSA based verifier with golang built-in keys.
@@ -36,12 +37,13 @@ func (ev *ed25519Verifier) Algorithm() Algorithm {
 	return AlgorithmEd25519
 }
 
-// Verify verifies digest with the public key, returning nil for success.
+// Verify verifies message content with the public key, returning nil for
+// success.
 // Otherwise, it returns ErrVerification.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8.2
-func (ev *ed25519Verifier) Verify(digest []byte, signature []byte) error {
-	if verified := ed25519.Verify(ev.key, digest, signature); !verified {
+func (ev *ed25519Verifier) Verify(content []byte, signature []byte) error {
+	if verified := ed25519.Verify(ev.key, content, signature); !verified {
 		return ErrVerification
 	}
 	return nil

--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -34,11 +34,8 @@ func Test_ed25519Signer(t *testing.T) {
 
 	// sign / verify round trip
 	// see also conformance_test.go for strict tests.
-	digest, err := alg.computeHash([]byte("hello world"))
-	if err != nil {
-		t.Fatalf("Algorithm.computeHash() error = %v", err)
-	}
-	sig, err := signer.Sign(rand.Reader, digest)
+	content := []byte("hello world")
+	sig, err := signer.Sign(rand.Reader, content)
 	if err != nil {
 		t.Fatalf("Sign() error = %v", err)
 	}
@@ -47,7 +44,7 @@ func Test_ed25519Signer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewVerifier() error = %v", err)
 	}
-	if err := verifier.Verify(digest, sig); err != nil {
+	if err := verifier.Verify(content, sig); err != nil {
 		t.Fatalf("Verifier.Verify() error = %v", err)
 	}
 }
@@ -58,7 +55,7 @@ func Test_ed25519Verifier_Verify_Success(t *testing.T) {
 	_, key := generateTestEd25519Key(t)
 
 	// generate a valid signature
-	digest, sig := signTestData(t, alg, key)
+	content, sig := signTestData(t, alg, key)
 
 	// set up verifier
 	verifier, err := NewVerifier(alg, key.Public())
@@ -73,7 +70,7 @@ func Test_ed25519Verifier_Verify_Success(t *testing.T) {
 	}
 
 	// verify round trip
-	if err := verifier.Verify(digest, sig); err != nil {
+	if err := verifier.Verify(content, sig); err != nil {
 		t.Fatalf("ed25519Verifier.Verify() error = %v", err)
 	}
 }
@@ -84,7 +81,7 @@ func Test_ed25519Verifier_Verify_KeyMismatch(t *testing.T) {
 	_, key := generateTestEd25519Key(t)
 
 	// generate a valid signature
-	digest, sig := signTestData(t, alg, key)
+	content, sig := signTestData(t, alg, key)
 
 	// set up verifier with a different key / new key
 	vk, _ := generateTestEd25519Key(t)
@@ -93,7 +90,7 @@ func Test_ed25519Verifier_Verify_KeyMismatch(t *testing.T) {
 	}
 
 	// verification should fail on key mismatch
-	if err := verifier.Verify(digest, sig); err != ErrVerification {
+	if err := verifier.Verify(content, sig); err != ErrVerification {
 		t.Fatalf("ed25519Verifier.Verify() error = %v, wantErr %v", err, ErrVerification)
 	}
 }
@@ -104,7 +101,7 @@ func Test_ed25519Verifier_Verify_InvalidSignature(t *testing.T) {
 	vk, sk := generateTestEd25519Key(t)
 
 	// generate a valid signature with a tampered one
-	digest, sig := signTestData(t, alg, sk)
+	content, sig := signTestData(t, alg, sk)
 	tamperedSig := make([]byte, len(sig))
 	copy(tamperedSig, sig)
 	tamperedSig[0]++
@@ -142,7 +139,7 @@ func Test_ed25519Verifier_Verify_InvalidSignature(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := verifier.Verify(digest, tt.signature); err != ErrVerification {
+			if err := verifier.Verify(content, tt.signature); err != ErrVerification {
 				t.Errorf("ed25519Verifier.Verify() error = %v, wantErr %v", err, ErrVerification)
 			}
 		})

--- a/errors.go
+++ b/errors.go
@@ -7,7 +7,6 @@ var (
 	ErrAlgorithmMismatch     = errors.New("algorithm mismatch")
 	ErrAlgorithmNotFound     = errors.New("algorithm not found")
 	ErrAlgorithmNotSupported = errors.New("algorithm not supported")
-	ErrAlgorithmRegistered   = errors.New("algorithm registered")
 	ErrEmptySignature        = errors.New("empty signature")
 	ErrInvalidAlgorithm      = errors.New("invalid algorithm")
 	ErrMissingPayload        = errors.New("missing payload")

--- a/errors.go
+++ b/errors.go
@@ -12,6 +12,5 @@ var (
 	ErrMissingPayload        = errors.New("missing payload")
 	ErrNoSignatures          = errors.New("no signatures attached")
 	ErrUnavailableHashFunc   = errors.New("hash function is not available")
-	ErrUnknownAlgorithm      = errors.New("unknown algorithm")
 	ErrVerification          = errors.New("verification error")
 )

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -58,6 +58,9 @@ func FuzzSign1Message_UnmarshalCBOR(f *testing.F) {
 			return false
 		}
 		b1, err := enc.Marshal(tmp)
+		if err != nil {
+			return false
+		}
 		return bytes.Equal(b, b1)
 	}
 	f.Fuzz(func(t *testing.T, b []byte) {

--- a/rsa.go
+++ b/rsa.go
@@ -24,11 +24,8 @@ func (rs *rsaSigner) Algorithm() Algorithm {
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8
 func (rs *rsaSigner) Sign(rand io.Reader, content []byte) ([]byte, error) {
-	hash, ok := rs.alg.hashFunc()
-	if !ok {
-		return nil, ErrInvalidAlgorithm
-	}
-	digest, err := rs.alg.computeHash(content)
+	hash := rs.alg.hashFunc()
+	digest, err := computeHash(hash, content)
 	if err != nil {
 		return nil, err
 	}
@@ -57,11 +54,8 @@ func (rv *rsaVerifier) Algorithm() Algorithm {
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8
 func (rv *rsaVerifier) Verify(content []byte, signature []byte) error {
-	hash, ok := rv.alg.hashFunc()
-	if !ok {
-		return ErrInvalidAlgorithm
-	}
-	digest, err := rv.alg.computeHash(content)
+	hash := rv.alg.hashFunc()
+	digest, err := computeHash(hash, content)
 	if err != nil {
 		return err
 	}

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -34,11 +34,8 @@ func Test_rsaSigner(t *testing.T) {
 
 	// sign / verify round trip
 	// see also conformance_test.go for strict tests.
-	digest, err := alg.computeHash([]byte("hello world"))
-	if err != nil {
-		t.Fatalf("Algorithm.computeHash() error = %v", err)
-	}
-	sig, err := signer.Sign(rand.Reader, digest)
+	content := []byte("hello world")
+	sig, err := signer.Sign(rand.Reader, content)
 	if err != nil {
 		t.Fatalf("Sign() error = %v", err)
 	}
@@ -47,7 +44,7 @@ func Test_rsaSigner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewVerifier() error = %v", err)
 	}
-	if err := verifier.Verify(digest, sig); err != nil {
+	if err := verifier.Verify(content, sig); err != nil {
 		t.Fatalf("Verifier.Verify() error = %v", err)
 	}
 }
@@ -58,7 +55,7 @@ func Test_rsaVerifier_Verify_Success(t *testing.T) {
 	key := generateTestRSAKey(t)
 
 	// generate a valid signature
-	digest, sig := signTestData(t, alg, key)
+	content, sig := signTestData(t, alg, key)
 
 	// set up verifier
 	verifier, err := NewVerifier(alg, key.Public())
@@ -73,7 +70,7 @@ func Test_rsaVerifier_Verify_Success(t *testing.T) {
 	}
 
 	// verify round trip
-	if err := verifier.Verify(digest, sig); err != nil {
+	if err := verifier.Verify(content, sig); err != nil {
 		t.Fatalf("rsaVerifier.Verify() error = %v", err)
 	}
 }
@@ -84,7 +81,7 @@ func Test_rsaVerifier_Verify_AlgorithmMismatch(t *testing.T) {
 	key := generateTestRSAKey(t)
 
 	// generate a valid signature
-	digest, sig := signTestData(t, alg, key)
+	content, sig := signTestData(t, alg, key)
 
 	// set up verifier with a different algorithm
 	verifier := &rsaVerifier{
@@ -93,7 +90,7 @@ func Test_rsaVerifier_Verify_AlgorithmMismatch(t *testing.T) {
 	}
 
 	// verification should fail on algorithm mismatch
-	if err := verifier.Verify(digest, sig); err != ErrVerification {
+	if err := verifier.Verify(content, sig); err != ErrVerification {
 		t.Fatalf("rsaVerifier.Verify() error = %v, wantErr %v", err, ErrVerification)
 	}
 }
@@ -104,7 +101,7 @@ func Test_rsaVerifier_Verify_KeyMismatch(t *testing.T) {
 	key := generateTestRSAKey(t)
 
 	// generate a valid signature
-	digest, sig := signTestData(t, alg, key)
+	content, sig := signTestData(t, alg, key)
 
 	// set up verifier with a different key / new key
 	key = generateTestRSAKey(t)
@@ -114,7 +111,7 @@ func Test_rsaVerifier_Verify_KeyMismatch(t *testing.T) {
 	}
 
 	// verification should fail on key mismatch
-	if err := verifier.Verify(digest, sig); err != ErrVerification {
+	if err := verifier.Verify(content, sig); err != ErrVerification {
 		t.Fatalf("rsaVerifier.Verify() error = %v, wantErr %v", err, ErrVerification)
 	}
 }
@@ -125,7 +122,7 @@ func Test_rsaVerifier_Verify_InvalidSignature(t *testing.T) {
 	key := generateTestRSAKey(t)
 
 	// generate a valid signature with a tampered one
-	digest, sig := signTestData(t, alg, key)
+	content, sig := signTestData(t, alg, key)
 	tamperedSig := make([]byte, len(sig))
 	copy(tamperedSig, sig)
 	tamperedSig[0]++
@@ -164,7 +161,7 @@ func Test_rsaVerifier_Verify_InvalidSignature(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := verifier.Verify(digest, tt.signature); err != ErrVerification {
+			if err := verifier.Verify(content, tt.signature); err != ErrVerification {
 				t.Errorf("rsaVerifier.Verify() error = %v, wantErr %v", err, ErrVerification)
 			}
 		})

--- a/sign.go
+++ b/sign.go
@@ -11,10 +11,10 @@ import (
 
 // signature represents a COSE_Signature CBOR object:
 //
-//   COSE_Signature =  [
-//       Headers,
-//       signature : bstr
-//   ]
+//	COSE_Signature =  [
+//	    Headers,
+//	    signature : bstr
+//	]
 //
 // Reference: https://tools.ietf.org/html/rfc8152#section-4.1
 type signature struct {
@@ -33,11 +33,10 @@ var signaturePrefix = []byte{
 //
 // Reference: https://tools.ietf.org/html/rfc8152#section-4.1
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 type Signature struct {
 	Headers   Headers
 	Signature []byte
@@ -45,11 +44,10 @@ type Signature struct {
 
 // NewSignature returns a Signature with header initialized.
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 func NewSignature() *Signature {
 	return &Signature{
 		Headers: Headers{
@@ -61,11 +59,10 @@ func NewSignature() *Signature {
 
 // MarshalCBOR encodes Signature into a COSE_Signature object.
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 func (s *Signature) MarshalCBOR() ([]byte, error) {
 	if s == nil {
 		return nil, errors.New("cbor: MarshalCBOR on nil Signature pointer")
@@ -87,11 +84,10 @@ func (s *Signature) MarshalCBOR() ([]byte, error) {
 
 // UnmarshalCBOR decodes a COSE_Signature object into Signature.
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 func (s *Signature) UnmarshalCBOR(data []byte) error {
 	if s == nil {
 		return errors.New("cbor: UnmarshalCBOR on nil Signature pointer")
@@ -131,11 +127,10 @@ func (s *Signature) UnmarshalCBOR(data []byte) error {
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 func (s *Signature) Sign(rand io.Reader, signer Signer, protected cbor.RawMessage, payload, external []byte) error {
 	if s == nil {
 		return errors.New("signing nil Signature")
@@ -158,11 +153,11 @@ func (s *Signature) Sign(rand io.Reader, signer Signer, protected cbor.RawMessag
 	}
 
 	// sign the message
-	digest, err := s.digestToBeSigned(alg, protected, payload, external)
+	toBeSigned, err := s.toBeSigned(alg, protected, payload, external)
 	if err != nil {
 		return err
 	}
-	sig, err := signer.Sign(rand, digest)
+	sig, err := signer.Sign(rand, toBeSigned)
 	if err != nil {
 		return err
 	}
@@ -178,11 +173,10 @@ func (s *Signature) Sign(rand io.Reader, signer Signer, protected cbor.RawMessag
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 func (s *Signature) Verify(verifier Verifier, protected cbor.RawMessage, payload, external []byte) error {
 	if s == nil {
 		return errors.New("verifying nil Signature")
@@ -206,20 +200,17 @@ func (s *Signature) Verify(verifier Verifier, protected cbor.RawMessage, payload
 	}
 
 	// verify the message
-	digest, err := s.digestToBeSigned(alg, protected, payload, external)
+	toBeSigned, err := s.toBeSigned(alg, protected, payload, external)
 	if err != nil {
 		return err
 	}
-	return verifier.Verify(digest, s.Signature)
+	return verifier.Verify(toBeSigned, s.Signature)
 }
 
-// digestToBeSigned constructs Sig_structure, computes ToBeSigned, and returns
-// the digest of ToBeSigned.
-// If the signing algorithm does not have a hash algorithm associated,
-// ToBeSigned is returned instead.
+// toBeSigned constructs Sig_structure, computes and returns ToBeSigned.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
-func (s *Signature) digestToBeSigned(alg Algorithm, bodyProtected cbor.RawMessage, payload, external []byte) ([]byte, error) {
+func (s *Signature) toBeSigned(alg Algorithm, bodyProtected cbor.RawMessage, payload, external []byte) ([]byte, error) {
 	// create a Sig_structure and populate it with the appropriate fields.
 	//
 	//   Sig_structure = [
@@ -247,23 +238,16 @@ func (s *Signature) digestToBeSigned(alg Algorithm, bodyProtected cbor.RawMessag
 
 	// create the value ToBeSigned by encoding the Sig_structure to a byte
 	// string.
-	toBeSigned, err := encMode.Marshal(sigStructure)
-	if err != nil {
-		return nil, err
-	}
-
-	// hash toBeSigned if there is a hash algorithm associated with the signing
-	// algorithm.
-	return alg.computeHash(toBeSigned)
+	return encMode.Marshal(sigStructure)
 }
 
 // signMessage represents a COSE_Sign CBOR object:
 //
-//   COSE_Sign = [
-//       Headers,
-//       payload : bstr / nil,
-//       signatures : [+ COSE_Signature]
-//   ]
+//	COSE_Sign = [
+//	    Headers,
+//	    payload : bstr / nil,
+//	    signatures : [+ COSE_Signature]
+//	]
 //
 // Reference: https://tools.ietf.org/html/rfc8152#section-4.1
 type signMessage struct {
@@ -284,11 +268,10 @@ var signMessagePrefix = []byte{
 //
 // Reference: https://tools.ietf.org/html/rfc8152#section-4.1
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 type SignMessage struct {
 	Headers    Headers
 	Payload    []byte
@@ -297,11 +280,10 @@ type SignMessage struct {
 
 // NewSignMessage returns a SignMessage with header initialized.
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 func NewSignMessage() *SignMessage {
 	return &SignMessage{
 		Headers: Headers{
@@ -313,11 +295,10 @@ func NewSignMessage() *SignMessage {
 
 // MarshalCBOR encodes SignMessage into a COSE_Sign_Tagged object.
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 func (m *SignMessage) MarshalCBOR() ([]byte, error) {
 	if m == nil {
 		return nil, errors.New("cbor: MarshalCBOR on nil SignMessage pointer")
@@ -351,11 +332,10 @@ func (m *SignMessage) MarshalCBOR() ([]byte, error) {
 
 // UnmarshalCBOR decodes a COSE_Sign_Tagged object into SignMessage.
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 func (m *SignMessage) UnmarshalCBOR(data []byte) error {
 	if m == nil {
 		return errors.New("cbor: UnmarshalCBOR on nil SignMessage pointer")
@@ -405,11 +385,10 @@ func (m *SignMessage) UnmarshalCBOR(data []byte) error {
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 func (m *SignMessage) Sign(rand io.Reader, external []byte, signers ...Signer) error {
 	if m == nil {
 		return errors.New("signing nil SignMessage")
@@ -451,11 +430,10 @@ func (m *SignMessage) Sign(rand io.Reader, external []byte, signers ...Signer) e
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
 //
-// Experimental
+// # Experimental
 //
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
-//
 func (m *SignMessage) Verify(external []byte, verifiers ...Verifier) error {
 	if m == nil {
 		return errors.New("verifying nil SignMessage")

--- a/sign.go
+++ b/sign.go
@@ -153,7 +153,7 @@ func (s *Signature) Sign(rand io.Reader, signer Signer, protected cbor.RawMessag
 	}
 
 	// sign the message
-	toBeSigned, err := s.toBeSigned(alg, protected, payload, external)
+	toBeSigned, err := s.toBeSigned(protected, payload, external)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func (s *Signature) Verify(verifier Verifier, protected cbor.RawMessage, payload
 	}
 
 	// verify the message
-	toBeSigned, err := s.toBeSigned(alg, protected, payload, external)
+	toBeSigned, err := s.toBeSigned(protected, payload, external)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func (s *Signature) Verify(verifier Verifier, protected cbor.RawMessage, payload
 // toBeSigned constructs Sig_structure, computes and returns ToBeSigned.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
-func (s *Signature) toBeSigned(alg Algorithm, bodyProtected cbor.RawMessage, payload, external []byte) ([]byte, error) {
+func (s *Signature) toBeSigned(bodyProtected cbor.RawMessage, payload, external []byte) ([]byte, error) {
 	// create a Sig_structure and populate it with the appropriate fields.
 	//
 	//   Sig_structure = [

--- a/sign1.go
+++ b/sign1.go
@@ -138,7 +138,7 @@ func (m *Sign1Message) Sign(rand io.Reader, external []byte, signer Signer) erro
 	}
 
 	// sign the message
-	toBeSigned, err := m.toBeSigned(alg, external)
+	toBeSigned, err := m.toBeSigned(external)
 	if err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func (m *Sign1Message) Verify(external []byte, verifier Verifier) error {
 	}
 
 	// verify the message
-	toBeSigned, err := m.toBeSigned(alg, external)
+	toBeSigned, err := m.toBeSigned(external)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func (m *Sign1Message) Verify(external []byte, verifier Verifier) error {
 // toBeSigned constructs Sig_structure, computes and returns ToBeSigned.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
-func (m *Sign1Message) toBeSigned(alg Algorithm, external []byte) ([]byte, error) {
+func (m *Sign1Message) toBeSigned(external []byte) ([]byte, error) {
 	// create a Sig_structure and populate it with the appropriate fields.
 	//
 	//   Sig_structure = [

--- a/sign1.go
+++ b/sign1.go
@@ -10,11 +10,11 @@ import (
 
 // sign1Message represents a COSE_Sign1 CBOR object:
 //
-//   COSE_Sign1 = [
-//       Headers,
-//       payload : bstr / nil,
-//       signature : bstr
-//   ]
+//	COSE_Sign1 = [
+//	    Headers,
+//	    payload : bstr / nil,
+//	    signature : bstr
+//	]
 //
 // Reference: https://tools.ietf.org/html/rfc8152#section-4.2
 type sign1Message struct {
@@ -138,11 +138,11 @@ func (m *Sign1Message) Sign(rand io.Reader, external []byte, signer Signer) erro
 	}
 
 	// sign the message
-	digest, err := m.digestToBeSigned(alg, external)
+	toBeSigned, err := m.toBeSigned(alg, external)
 	if err != nil {
 		return err
 	}
-	sig, err := signer.Sign(rand, digest)
+	sig, err := signer.Sign(rand, toBeSigned)
 	if err != nil {
 		return err
 	}
@@ -175,20 +175,17 @@ func (m *Sign1Message) Verify(external []byte, verifier Verifier) error {
 	}
 
 	// verify the message
-	digest, err := m.digestToBeSigned(alg, external)
+	toBeSigned, err := m.toBeSigned(alg, external)
 	if err != nil {
 		return err
 	}
-	return verifier.Verify(digest, m.Signature)
+	return verifier.Verify(toBeSigned, m.Signature)
 }
 
-// digestToBeSigned constructs Sig_structure, computes ToBeSigned, and returns
-// the digest of ToBeSigned.
-// If the signing algorithm does not have a hash algorithm associated,
-// ToBeSigned is returned instead.
+// toBeSigned constructs Sig_structure, computes and returns ToBeSigned.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
-func (m *Sign1Message) digestToBeSigned(alg Algorithm, external []byte) ([]byte, error) {
+func (m *Sign1Message) toBeSigned(alg Algorithm, external []byte) ([]byte, error) {
 	// create a Sig_structure and populate it with the appropriate fields.
 	//
 	//   Sig_structure = [
@@ -214,14 +211,7 @@ func (m *Sign1Message) digestToBeSigned(alg Algorithm, external []byte) ([]byte,
 
 	// create the value ToBeSigned by encoding the Sig_structure to a byte
 	// string.
-	toBeSigned, err := encMode.Marshal(sigStructure)
-	if err != nil {
-		return nil, err
-	}
-
-	// hash toBeSigned if there is a hash algorithm associated with the signing
-	// algorithm.
-	return alg.computeHash(toBeSigned)
+	return encMode.Marshal(sigStructure)
 }
 
 // Sign1 signs a Sign1Message using the provided Signer.

--- a/sign1_test.go
+++ b/sign1_test.go
@@ -672,8 +672,6 @@ func TestSign1Message_Sign_Internal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hash := crypto.SHA256
-			RegisterAlgorithm(algorithmMock, "Mock", hash, nil)
-			defer resetExtendedAlgorithm()
 
 			sig := make([]byte, 64)
 			_, err := rand.Read(sig)

--- a/sign1_test.go
+++ b/sign1_test.go
@@ -2,7 +2,6 @@ package cose
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/rand"
 	"reflect"
 	"testing"
@@ -671,18 +670,13 @@ func TestSign1Message_Sign_Internal(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hash := crypto.SHA256
-
 			sig := make([]byte, 64)
 			_, err := rand.Read(sig)
 			if err != nil {
 				t.Fatalf("rand.Read() error = %v", err)
 			}
-			h := hash.New()
-			h.Write(tt.toBeSigned)
-			digest := h.Sum(nil)
 			signer := newMockSigner(t)
-			signer.setup(digest, sig)
+			signer.setup(tt.toBeSigned, sig)
 
 			msg := tt.msg
 			if err := msg.Sign(rand.Reader, tt.external, signer); err != nil {

--- a/sign_test.go
+++ b/sign_test.go
@@ -748,8 +748,6 @@ func TestSignature_Sign_Internal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hash := crypto.SHA256
-			RegisterAlgorithm(algorithmMock, "Mock", hash, nil)
-			defer resetExtendedAlgorithm()
 
 			want := make([]byte, 64)
 			_, err := rand.Read(want)

--- a/sign_test.go
+++ b/sign_test.go
@@ -2,7 +2,6 @@ package cose
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/rand"
 	"reflect"
 	"testing"
@@ -747,18 +746,13 @@ func TestSignature_Sign_Internal(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hash := crypto.SHA256
-
 			want := make([]byte, 64)
 			_, err := rand.Read(want)
 			if err != nil {
 				t.Fatalf("rand.Read() error = %v", err)
 			}
-			h := hash.New()
-			h.Write(tt.toBeSigned)
-			digest := h.Sum(nil)
 			signer := newMockSigner(t)
-			signer.setup(digest, want)
+			signer.setup(tt.toBeSigned, want)
 
 			sig := tt.sig
 			if err := sig.Sign(rand.Reader, signer, tt.protected, tt.payload, tt.external); err != nil {

--- a/signer.go
+++ b/signer.go
@@ -15,11 +15,12 @@ type Signer interface {
 	// Algorithm returns the signing algorithm associated with the private key.
 	Algorithm() Algorithm
 
-	// Sign signs digest with the private key, possibly using entropy from rand.
+	// Sign signs message content with the private key, possibly using entropy
+	// from rand.
 	// The resulting signature should follow RFC 8152 section 8.
 	//
 	// Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8
-	Sign(rand io.Reader, digest []byte) ([]byte, error)
+	Sign(rand io.Reader, content []byte) ([]byte, error)
 }
 
 // NewSigner returns a signer with a given signing key.

--- a/signer_test.go
+++ b/signer_test.go
@@ -10,16 +10,13 @@ import (
 	"testing"
 )
 
-func signTestData(t *testing.T, alg Algorithm, key crypto.Signer) (digest, sig []byte) {
+func signTestData(t *testing.T, alg Algorithm, key crypto.Signer) (content, sig []byte) {
 	signer, err := NewSigner(alg, key)
 	if err != nil {
 		t.Fatalf("NewSigner() error = %v", err)
 	}
-	digest, err = alg.computeHash([]byte("hello world"))
-	if err != nil {
-		t.Fatalf("Algorithm.computeHash() error = %v", err)
-	}
-	sig, err = signer.Sign(rand.Reader, digest)
+	content = []byte("hello world")
+	sig, err = signer.Sign(rand.Reader, content)
 	if err != nil {
 		t.Fatalf("Sign() error = %v", err)
 	}

--- a/signer_test.go
+++ b/signer_test.go
@@ -147,18 +147,18 @@ func newMockSigner(t *testing.T) *mockSigner {
 	}
 }
 
-func (m *mockSigner) setup(digest, sig []byte) {
-	m.m[hex.EncodeToString(digest)] = hex.EncodeToString(sig) // deep copy
+func (m *mockSigner) setup(content, sig []byte) {
+	m.m[hex.EncodeToString(content)] = hex.EncodeToString(sig) // deep copy
 }
 
 func (m *mockSigner) Algorithm() Algorithm {
 	return algorithmMock
 }
 
-func (m *mockSigner) Sign(rand io.Reader, digest []byte) ([]byte, error) {
-	sigHex, ok := m.m[hex.EncodeToString(digest)]
+func (m *mockSigner) Sign(rand io.Reader, content []byte) ([]byte, error) {
+	sigHex, ok := m.m[hex.EncodeToString(content)]
 	if !ok {
-		m.t.Fatalf("mockSigner: not setup: %v", digest)
+		m.t.Fatalf("mockSigner: not setup: %v", content)
 	}
 	sig, err := hex.DecodeString(sigHex)
 	if err != nil {

--- a/verifier.go
+++ b/verifier.go
@@ -14,11 +14,12 @@ type Verifier interface {
 	// Algorithm returns the signing algorithm associated with the public key.
 	Algorithm() Algorithm
 
-	// Verify verifies digest with the public key, returning nil for success.
+	// Verify verifies message content with the public key, returning nil for
+	// success.
 	// Otherwise, it returns ErrVerification.
 	//
 	// Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8
-	Verify(digest, signature []byte) error
+	Verify(content, signature []byte) error
 }
 
 // NewVerifier returns a verifier with a given public key.


### PR DESCRIPTION
Resolves #100

Changes:
- `Sign()` in the `Signer` interface accepts message content instead of digest.
- `Verify()` in the `Verifier` interface accepts message content instead of digest.
- External algorithm registration is removed since signing and verification no longer require digest computation.
- Improved doc comments.
- Fixes tests.