### PR TITLE
chore: upgrade ci to go 1.18 and go 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.18, 1.19]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
+        check-latest: true
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Run tests


### PR DESCRIPTION
Resolves #102
Note that `go.mod` is already at `go 1.18`.

Signed-off-by: Shiwei Zhang <shizh@microsoft.com>