### PR TITLE
Add CODEOWNERS Fixes #131

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,4 @@
 # To be kept in sync with: [community/OWNERS](https://github.com/veraison/community/blob/main/OWNERS) 
 # and the GitHub Team: [go-cose-maintainers](https://github.com/orgs/veraison/teams/go-cose-maintainers)
 
-henkbirkholz
-qmuntal
-setrofim
-shizhMSFT
-simonfrost-arm
-SteveLasker
-thomas-fossati
-yogeshbdeshpande
+* henkbirkholz qmuntal setrofim shizhMSFT simonfrost-arm SteveLasker thomas-fossati yogeshbdeshpande

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# To be kept in sync with: [community/OWNERS](https://github.com/veraison/community/blob/main/OWNERS) 
+# and the GitHub Team: [go-cose-maintainers](https://github.com/orgs/veraison/teams/go-cose-maintainers)
+
+- henkbirkholz
+- qmuntal
+- setrofim
+- shizhMSFT
+- simonfrost-arm
+- SteveLasker
+- thomas-fossati
+- yogeshbdeshpande
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,12 @@
 # To be kept in sync with: [community/OWNERS](https://github.com/veraison/community/blob/main/OWNERS) 
 # and the GitHub Team: [go-cose-maintainers](https://github.com/orgs/veraison/teams/go-cose-maintainers)
 
-- henkbirkholz
-- qmuntal
-- setrofim
-- shizhMSFT
-- simonfrost-arm
-- SteveLasker
-- thomas-fossati
-- yogeshbdeshpande
+henkbirkholz
+qmuntal
+setrofim
+shizhMSFT
+simonfrost-arm
+SteveLasker
+thomas-fossati
+yogeshbdeshpande
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,4 +9,3 @@ simonfrost-arm
 SteveLasker
 thomas-fossati
 yogeshbdeshpande
-


### PR DESCRIPTION
This merges the people listed under:
- the GitHub Team: [go-cose-maintainers](https://github.com/orgs/veraison/teams/go-cose-maintainers)
- and those listed in: [community/OWNERS](https://github.com/veraison/community/blob/main/OWNERS) 
