### PR TITLE
Add Roy Williams as a maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# To be kept in sync with: [community/OWNERS](https://github.com/veraison/community/blob/main/OWNERS) 
+# and the GitHub Team: [go-cose-maintainers](https://github.com/orgs/veraison/teams/go-cose-maintainers)
+
+henkbirkholz
+qmuntal
+roywill
+setrofim
+shizhMSFT
+simonfrost-arm
+SteveLasker
+thomas-fossati
+yogeshbdeshpande

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,4 @@
 # To be kept in sync with: [community/OWNERS](https://github.com/veraison/community/blob/main/OWNERS) 
 # and the GitHub Team: [go-cose-maintainers](https://github.com/orgs/veraison/teams/go-cose-maintainers)
 
-henkbirkholz
-qmuntal
-roywill
-setrofim
-shizhMSFT
-simonfrost-arm
-SteveLasker
-thomas-fossati
-yogeshbdeshpande
+* henkbirkholz qmuntal roywill setrofim shizhMSFT simonfrost-arm SteveLasker thomas-fossati yogeshbdeshpande 


### PR DESCRIPTION
In the [February 10, 2023 go-cose community meeting](https://veraison.zulipchat.com/#narrow/stream/317999-go-cose-meetings/topic/Meeting.2010-02-2023), @roywill was nominated as a maintainer.
Per [veraison governance: Sub Project Maintainers](https://github.com/veraison/community/blob/main/GOVERNANCE.md#sub-project-maintainers)  a super majority LGTM of this PR affirms Roy joining the team.

NOTE: This PR is a delta from #133. 
Maintainers, please LGTM/merge #133 prior to merging this PR.
