### PR TITLE
Add support for `RS256`, `COSEAlgorithmIdentifier -257`

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -22,6 +22,10 @@ const (
 	// Requires an available crypto.SHA512.
 	AlgorithmPS512 Algorithm = -39
 
+	// RSASSA-PKCS1-v1_5 using SHA-256 by RFC 8812.
+	// Requires an available crypto.SHA256.
+	AlgorithmRS256 Algorithm = -257
+
 	// ECDSA w/ SHA-256 by RFC 8152.
 	// Requires an available crypto.SHA256.
 	AlgorithmES256 Algorithm = -7
@@ -57,6 +61,8 @@ func (a Algorithm) String() string {
 		return "PS384"
 	case AlgorithmPS512:
 		return "PS512"
+	case AlgorithmRS256:
+		return "RS256"
 	case AlgorithmES256:
 		return "ES256"
 	case AlgorithmES384:
@@ -76,7 +82,7 @@ func (a Algorithm) String() string {
 // library.
 func (a Algorithm) hashFunc() crypto.Hash {
 	switch a {
-	case AlgorithmPS256, AlgorithmES256:
+	case AlgorithmPS256, AlgorithmES256, AlgorithmRS256:
 		return crypto.SHA256
 	case AlgorithmPS384, AlgorithmES384:
 		return crypto.SHA384

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -32,6 +32,11 @@ func TestAlgorithm_String(t *testing.T) {
 			want: "PS512",
 		},
 		{
+			name: "RS256",
+			alg:  AlgorithmRS256,
+			want: "RS256",
+		},
+		{
 			name: "ES256",
 			alg:  AlgorithmES256,
 			want: "ES256",

--- a/conformance_test.go
+++ b/conformance_test.go
@@ -308,6 +308,8 @@ func mustNameToAlg(name string) cose.Algorithm {
 		return cose.AlgorithmPS384
 	case "PS512":
 		return cose.AlgorithmPS512
+	case "RS256":
+		return cose.AlgorithmRS256
 	case "ES256":
 		return cose.AlgorithmES256
 	case "ES384":

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -23,6 +23,7 @@ import (
 
 var supportedAlgorithms = [...]cose.Algorithm{
 	cose.AlgorithmPS256, cose.AlgorithmPS384, cose.AlgorithmPS512,
+	cose.AlgorithmRS256,
 	cose.AlgorithmES256, cose.AlgorithmES384, cose.AlgorithmES512,
 	cose.AlgorithmEd25519,
 }
@@ -175,6 +176,8 @@ func newSignerWithEphemeralKey(alg cose.Algorithm) (sv signVerifier, err error) 
 		key, err = rsa.GenerateKey(rand.Reader, 3072)
 	case cose.AlgorithmPS512:
 		key, err = rsa.GenerateKey(rand.Reader, 4096)
+	case cose.AlgorithmRS256:
+		key, err = rsa.GenerateKey(rand.Reader, 2048)
 	case cose.AlgorithmES256:
 		key, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	case cose.AlgorithmES384:

--- a/signer.go
+++ b/signer.go
@@ -38,7 +38,7 @@ type Signer interface {
 // implement `crypto.Signer`.
 func NewSigner(alg Algorithm, key crypto.Signer) (Signer, error) {
 	switch alg {
-	case AlgorithmPS256, AlgorithmPS384, AlgorithmPS512:
+	case AlgorithmPS256, AlgorithmPS384, AlgorithmPS512, AlgorithmRS256:
 		vk, ok := key.Public().(*rsa.PublicKey)
 		if !ok {
 			return nil, fmt.Errorf("%v: %w", alg, ErrInvalidPubKey)

--- a/signer_test.go
+++ b/signer_test.go
@@ -111,6 +111,15 @@ func TestNewSigner(t *testing.T) {
 			wantErr: "RSA key must be at least 2048 bits long",
 		},
 		{
+			name: "rsa pkcs1 signer",
+			alg:  AlgorithmRS256,
+			key:  rsaKey,
+			want: &rsaSigner{
+				alg: AlgorithmRS256,
+				key: rsaKey,
+			},
+		},
+		{
 			name:    "unknown algorithm",
 			alg:     0,
 			wantErr: "algorithm not supported",

--- a/verifier.go
+++ b/verifier.go
@@ -27,7 +27,7 @@ type Verifier interface {
 // `*ecdsa.PublicKey`, and `ed25519.PublicKey` are accepted.
 func NewVerifier(alg Algorithm, key crypto.PublicKey) (Verifier, error) {
 	switch alg {
-	case AlgorithmPS256, AlgorithmPS384, AlgorithmPS512:
+	case AlgorithmPS256, AlgorithmPS384, AlgorithmPS512, AlgorithmRS256:
 		vk, ok := key.(*rsa.PublicKey)
 		if !ok {
 			return nil, fmt.Errorf("%v: %w", alg, ErrInvalidPubKey)

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -95,6 +95,15 @@ func TestNewVerifier(t *testing.T) {
 			},
 		},
 		{
+			name: "rsa pkcs1 verifier",
+			alg:  AlgorithmRS256,
+			key:  rsaKey,
+			want: &rsaVerifier{
+				alg: AlgorithmRS256,
+				key: rsaKey,
+			},
+		},
+		{
 			name:    "rsa invalid public key",
 			alg:     AlgorithmPS256,
 			key:     ecdsaKey,


### PR DESCRIPTION
This PR adds support for RSASSA PKCS#1 v1.5 signing and verification. I started with just `RS256`, but I can add the others too if this PR will be considered to be merged at some point.

Let me know if you want the tests to be more like a table; currently they're more like multiple copies.

I noticed that registering an algorithm was removed with https://github.com/veraison/go-cose/pull/101, but I could use the `RS256` (and potentially others) for some things, primarily for checking/validating values to be valid COSE values. Adding in the `RS256` in all required places seemed to be the way to go, ~~or will `RegisterAlgorithm` be reconsidered?~~ I noticed signing and verifying can be done backed by a user-provided `Signer` and `Verifier`. Should I remove the signing and verification code, and just keep the `AlgorithmRS256` around?