### PR TITLE
Fix intermittent failures in headers tests

### DIFF
--- a/headers_test.go
+++ b/headers_test.go
@@ -319,11 +319,18 @@ func TestProtectedHeader_UnmarshalCBOR(t *testing.T) {
 			wantErr: "cbor: require bstr type",
 		},
 		{
-			name: "iv and partial iv present",
+			name: "iv must be bstr",
 			data: []byte{
-				0x4b, 0xa2, 0x5, 0x63, 0x66, 0x6f, 0x6f, 0x6, 0x63, 0x62, 0x61, 0x72,
+				0x46, 0xa1, 0x5, 0x63, 0x66, 0x6f, 0x6f,
 			},
 			wantErr: "protected header: header parameter: IV: require bstr type",
+		},
+		{
+			name: "partial iv must be bstr",
+			data: []byte{
+				0x46, 0xa1, 0x6, 0x63, 0x62, 0x61, 0x72,
+			},
+			wantErr: "protected header: header parameter: Partial IV: require bstr type",
 		},
 	}
 	for _, tt := range tests {
@@ -703,11 +710,18 @@ func TestUnprotectedHeader_UnmarshalCBOR(t *testing.T) {
 			wantErr: "cbor: header label: int key must not be higher than 1<<63 - 1",
 		},
 		{
-			name: "iv and partial iv present",
+			name: "iv must be bstr",
 			data: []byte{
-				0xa2, 0x5, 0x63, 0x66, 0x6f, 0x6f, 0x6, 0x63, 0x62, 0x61, 0x72,
+				0xa1, 0x5, 0x63, 0x66, 0x6f, 0x6f,
 			},
 			wantErr: "unprotected header: header parameter: IV: require bstr type",
+		},
+		{
+			name: "partial iv must be bstr",
+			data: []byte{
+				0xa1, 0x6, 0x63, 0x62, 0x61, 0x72,
+			},
+			wantErr: "unprotected header: header parameter: Partial IV: require bstr type",
 		},
 		{
 			name: "critical present",


### PR DESCRIPTION
Split the "iv and partial iv present" test case into separate "iv present" and "partial iv present" cases in headers test.

The issue is that validateHeaderParameters takes a map of extracted header parameters and range's over them, validating each one. Ranging over maps in Go does not guarantee a stable order.

This meant that ether the "IV" or the "Partial IV" parameter could be checked first in the "iv and partial iv present" test case, resulting in different errors being reported on different runs.

The test harness only allows specifying one expected error, so when the order of the header params map iteration switched, the actual and expected errors didn't match resulting in test failure.

One way to fix it would be sort map values before iterating over them, however that would be an unnecessary overhead, since the order only matters in the context of the test (where a _specific_ error is expected).

Therefore, the alternative solution is to split the test case into two, with only one possible error resulting from each.