### PR TITLE
fix: typo UnataggedSign1Message -> UntaggedSign1Message

### DIFF
--- a/sign1.go
+++ b/sign1.go
@@ -262,7 +262,7 @@ func (m *UntaggedSign1Message) MarshalCBOR() ([]byte, error) {
 	return encMode.Marshal(content)
 }
 
-// UnmarshalCBOR decodes a COSE_Sign1 object into an UnataggedSign1Message.
+// UnmarshalCBOR decodes a COSE_Sign1 object into an UntaggedSign1Message.
 func (m *UntaggedSign1Message) UnmarshalCBOR(data []byte) error {
 	if m == nil {
 		return errors.New("cbor: UnmarshalCBOR on nil UntaggedSign1Message pointer")


### PR DESCRIPTION
Small change to fix the typo.