### PR TITLE
Retract v1.2.0 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,8 @@ go 1.18
 require github.com/fxamacker/cbor/v2 v2.4.0
 
 require github.com/x448/float16 v0.8.4 // indirect
+
+retract (
+	v1.2.1 // contains retractions only
+	v1.2.0 // published in error
+)


### PR DESCRIPTION
This release was published in error, as further work is required on COSE_Key.

This addresses https://github.com/veraison/go-cose/issues/152