### PR TITLE
Key fixes

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -18,4 +18,6 @@ var (
 	ErrNotPrivKey            = errors.New("not a private key")
 	ErrSignOpNotSupported    = errors.New("sign key_op not supported by key")
 	ErrVerifyOpNotSupported  = errors.New("verify key_op not supported by key")
+	ErrEC2NoPub              = errors.New("cannot create PrivateKey from EC2 key: missing X or Y")
+	ErrOKPNoPub              = errors.New("cannot create PrivateKey from OKP key: missing X")
 )

--- a/key.go
+++ b/key.go
@@ -641,6 +641,13 @@ func (k *Key) PrivateKey() (crypto.PrivateKey, error) {
 
 	switch alg {
 	case AlgorithmES256, AlgorithmES384, AlgorithmES512:
+		// RFC8152 allows omitting X and Y from private keys;
+		// crypto.PrivateKey assumes they are available.
+		// see https://www.rfc-editor.org/rfc/rfc8152#section-13.1.1
+		if len(k.X) == 0 || len(k.Y) == 0 {
+			return nil, ErrEC2NoPub
+		}
+
 		var curve elliptic.Curve
 
 		switch alg {
@@ -662,6 +669,13 @@ func (k *Key) PrivateKey() (crypto.PrivateKey, error) {
 
 		return priv, nil
 	case AlgorithmEd25519:
+		// RFC8152 allows omitting X from private keys;
+		// crypto.PrivateKey assumes it is available.
+		// see https://www.rfc-editor.org/rfc/rfc8152#section-13.2
+		if len(k.X) == 0 {
+			return nil, ErrOKPNoPub
+		}
+
 		buf := make([]byte, ed25519.PrivateKeySize)
 
 		copy(buf, k.D)

--- a/key.go
+++ b/key.go
@@ -456,23 +456,25 @@ func (k Key) Validate() error {
 	switch k.KeyType {
 	case KeyTypeEC2:
 		switch k.Curve {
-		case CurveP256, CurveP384, CurveP521:
-			// ok
-		default:
+		case CurveX25519, CurveX448, CurveEd25519, CurveEd448:
 			return fmt.Errorf(
-				"EC2 curve must be P-256, P-384, or P-521; found %q",
+				"Key type mismatch for curve %q (must be OKP, found EC2)",
 				k.Curve.String(),
 			)
+		default:
+			// ok -- a key may contain a currently unsupported curve
+			// see https://www.rfc-editor.org/rfc/rfc8152#section-13.1.1
 		}
 	case KeyTypeOKP:
 		switch k.Curve {
-		case CurveX25519, CurveX448, CurveEd25519, CurveEd448:
-			// ok
-		default:
+		case CurveP256, CurveP384, CurveP521:
 			return fmt.Errorf(
-				"OKP curve must be X25519, X448, Ed25519, or Ed448; found %q",
+				"Key type mismatch for curve %q (must be EC2, found OKP)",
 				k.Curve.String(),
 			)
+		default:
+			// ok -- a key may contain a currently unsupported curve
+			// see https://www.rfc-editor.org/rfc/rfc8152#section-13.2
 		}
 	case KeyTypeSymmetric:
 	default:

--- a/key.go
+++ b/key.go
@@ -777,7 +777,7 @@ func (k *Key) Verifier() (Verifier, error) {
 // must be explicitly set,so that this derivation is not used.
 func (k *Key) deriveAlgorithm() (Algorithm, error) {
 	switch k.KeyType {
-	case KeyTypeEC2, KeyTypeOKP:
+	case KeyTypeEC2:
 		switch k.Curve {
 		case CurveP256:
 			return AlgorithmES256, nil
@@ -785,10 +785,17 @@ func (k *Key) deriveAlgorithm() (Algorithm, error) {
 			return AlgorithmES384, nil
 		case CurveP521:
 			return AlgorithmES512, nil
+		default:
+			return AlgorithmInvalid, fmt.Errorf(
+				"unsupported curve %q for key type EC2", k.Curve.String())
+		}
+	case KeyTypeOKP:
+		switch k.Curve {
 		case CurveEd25519:
 			return AlgorithmEd25519, nil
 		default:
-			return AlgorithmInvalid, fmt.Errorf("unsupported curve %q", k.Curve.String())
+			return AlgorithmInvalid, fmt.Errorf(
+				"unsupported curve %q for key type OKP", k.Curve.String())
 		}
 	default:
 		// Symmetric algorithms are not supported in the current inmplementation.

--- a/key_test.go
+++ b/key_test.go
@@ -518,12 +518,28 @@ func Test_Key_ecdsa_signature_round_trip(t *testing.T) {
 
 func Test_Key_derive_algorithm(t *testing.T) {
 	k := Key{
+		KeyType: KeyTypeEC2,
+		Curve:   CurveEd25519,
+	}
+
+	_, err := k.AlgorithmOrDefault()
+	assertEqualError(t, err, "unsupported curve \"Ed25519\" for key type EC2")
+
+	k = Key{
+		KeyType: KeyTypeOKP,
+		Curve:   CurveP256,
+	}
+
+	_, err = k.AlgorithmOrDefault()
+	assertEqualError(t, err, "unsupported curve \"P-256\" for key type OKP")
+
+	k = Key{
 		KeyType: KeyTypeOKP,
 		Curve:   CurveX448,
 	}
 
-	_, err := k.AlgorithmOrDefault()
-	assertEqualError(t, err, "unsupported curve \"X448\"")
+	_, err = k.AlgorithmOrDefault()
+	assertEqualError(t, err, "unsupported curve \"X448\" for key type OKP")
 
 	k = Key{
 		KeyType: KeyTypeOKP,
@@ -588,7 +604,7 @@ func Test_Key_signer_validation(t *testing.T) {
 
 	key.Curve = CurveX448
 	_, err = key.Signer()
-	assertEqualError(t, err, "unsupported curve \"X448\"")
+	assertEqualError(t, err, "unsupported curve \"X448\" for key type OKP")
 }
 
 func Test_Key_verifier_validation(t *testing.T) {
@@ -631,7 +647,7 @@ func Test_Key_crypto_keys(t *testing.T) {
 	}
 
 	_, err = k.PublicKey()
-	assertEqualError(t, err, "unsupported curve \"X448\"")
+	assertEqualError(t, err, "unsupported curve \"X448\" for key type OKP")
 	_, err = k.PrivateKey()
-	assertEqualError(t, err, "unsupported curve \"X448\"")
+	assertEqualError(t, err, "unsupported curve \"X448\" for key type OKP")
 }

--- a/key_test.go
+++ b/key_test.go
@@ -650,4 +650,19 @@ func Test_Key_crypto_keys(t *testing.T) {
 	assertEqualError(t, err, "unsupported curve \"X448\" for key type OKP")
 	_, err = k.PrivateKey()
 	assertEqualError(t, err, "unsupported curve \"X448\" for key type OKP")
+
+	k = Key{
+		KeyType: KeyTypeOKP,
+		Curve:   CurveEd25519,
+		D:       []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+
+	_, err = k.PrivateKey()
+	assertEqualError(t, err, ErrOKPNoPub.Error())
+
+	k.KeyType = KeyTypeEC2
+	k.Curve = CurveP256
+
+	_, err = k.PrivateKey()
+	assertEqualError(t, err, ErrEC2NoPub.Error())
 }

--- a/key_test.go
+++ b/key_test.go
@@ -231,7 +231,7 @@ func Test_Key_UnmarshalCBOR(t *testing.T) {
 				0x01, 0x01, // kty: OKP
 				0x20, 0x01, // curve: CurveP256
 			},
-			WantErr:  "OKP curve must be X25519, X448, Ed25519, or Ed448; found \"P-256\"",
+			WantErr:  "Key type mismatch for curve \"P-256\" (must be EC2, found OKP)",
 			Validate: nil,
 		},
 		{
@@ -241,7 +241,7 @@ func Test_Key_UnmarshalCBOR(t *testing.T) {
 				0x01, 0x02, // kty: EC2
 				0x20, 0x06, // curve: CurveEd25519
 			},
-			WantErr:  "EC2 curve must be P-256, P-384, or P-521; found \"Ed25519\"",
+			WantErr:  "Key type mismatch for curve \"Ed25519\" (must be OKP, found EC2)",
 			Validate: nil,
 		},
 		{
@@ -565,7 +565,7 @@ func Test_Key_signer_validation(t *testing.T) {
 
 	key.KeyType = KeyTypeEC2
 	_, err = key.Signer()
-	assertEqualError(t, err, "EC2 curve must be P-256, P-384, or P-521; found \"Ed25519\"")
+	assertEqualError(t, err, "Key type mismatch for curve \"Ed25519\" (must be OKP, found EC2)")
 
 	key.Curve = CurveP256
 	_, err = key.Signer()
@@ -603,7 +603,7 @@ func Test_Key_verifier_validation(t *testing.T) {
 
 	key.KeyType = KeyTypeEC2
 	_, err = key.Verifier()
-	assertEqualError(t, err, "EC2 curve must be P-256, P-384, or P-521; found \"Ed25519\"")
+	assertEqualError(t, err, "Key type mismatch for curve \"Ed25519\" (must be OKP, found EC2)")
 
 	key.KeyType = KeyTypeOKP
 	key.KeyOps = []KeyOp{}

--- a/key_test.go
+++ b/key_test.go
@@ -90,7 +90,7 @@ func Test_KeyOp(t *testing.T) {
 
 	data = []byte{0x63, 0x66, 0x6f, 0x6f}
 	err = ko.UnmarshalCBOR(data)
-	assertEqualError(t, err, "unknown key_ops value \"foo\"")
+	assertEqualError(t, err, `unknown key_ops value "foo"`)
 
 	data = []byte{0x40}
 	err = ko.UnmarshalCBOR(data)
@@ -126,7 +126,7 @@ func Test_KeyType(t *testing.T) {
 
 	data = []byte{0x63, 0x66, 0x6f, 0x6f}
 	err = ko.UnmarshalCBOR(data)
-	assertEqualError(t, err, "unknown key type value \"foo\"")
+	assertEqualError(t, err, `unknown key type value "foo"`)
 
 	data = []byte{0x40}
 	err = ko.UnmarshalCBOR(data)
@@ -146,7 +146,7 @@ func Test_Curve(t *testing.T) {
 
 	data = []byte{0x63, 0x66, 0x6f, 0x6f}
 	err = c.UnmarshalCBOR(data)
-	assertEqualError(t, err, "unknown curve value \"foo\"")
+	assertEqualError(t, err, `unknown curve value "foo"`)
 
 	data = []byte{0x40}
 	err = c.UnmarshalCBOR(data)
@@ -231,7 +231,7 @@ func Test_Key_UnmarshalCBOR(t *testing.T) {
 				0x01, 0x01, // kty: OKP
 				0x20, 0x01, // curve: CurveP256
 			},
-			WantErr:  "Key type mismatch for curve \"P-256\" (must be EC2, found OKP)",
+			WantErr:  `Key type mismatch for curve "P-256" (must be EC2, found OKP)`,
 			Validate: nil,
 		},
 		{
@@ -241,7 +241,7 @@ func Test_Key_UnmarshalCBOR(t *testing.T) {
 				0x01, 0x02, // kty: EC2
 				0x20, 0x06, // curve: CurveEd25519
 			},
-			WantErr:  "Key type mismatch for curve \"Ed25519\" (must be OKP, found EC2)",
+			WantErr:  `Key type mismatch for curve "Ed25519" (must be OKP, found EC2)`,
 			Validate: nil,
 		},
 		{
@@ -297,7 +297,7 @@ func Test_Key_UnmarshalCBOR(t *testing.T) {
 				0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
 				0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
 			},
-			WantErr:  "found algorithm \"ES256\" (expected \"EdDSA\")",
+			WantErr:  `found algorithm "ES256" (expected "EdDSA")`,
 			Validate: nil,
 		},
 	}
@@ -385,7 +385,7 @@ func Test_Key_MarshalCBOR(t *testing.T) {
 
 	k.KeyType = KeyType(42)
 	_, err = k.MarshalCBOR()
-	wantErr := "invalid key type: \"unknown key type value 42\""
+	wantErr := `invalid key type: "unknown key type value 42"`
 	if err == nil || err.Error() != wantErr {
 		t.Errorf("Unexpected error: want %q, got %q", wantErr, err)
 	}
@@ -412,10 +412,10 @@ func Test_Key_Create_and_Validate(t *testing.T) {
 	assertEqual(t, x, key.X)
 
 	_, err = NewOKPKey(AlgorithmES256, x, nil)
-	assertEqualError(t, err, "unsupported algorithm \"ES256\"")
+	assertEqualError(t, err, `unsupported algorithm "ES256"`)
 
 	_, err = NewEC2Key(AlgorithmEd25519, x, y, nil)
-	assertEqualError(t, err, "unsupported algorithm \"EdDSA\"")
+	assertEqualError(t, err, `unsupported algorithm "EdDSA"`)
 
 	key, err = NewEC2Key(AlgorithmES256, x, y, nil)
 	requireNoError(t, err)
@@ -523,7 +523,7 @@ func Test_Key_derive_algorithm(t *testing.T) {
 	}
 
 	_, err := k.AlgorithmOrDefault()
-	assertEqualError(t, err, "unsupported curve \"Ed25519\" for key type EC2")
+	assertEqualError(t, err, `unsupported curve "Ed25519" for key type EC2`)
 
 	k = Key{
 		KeyType: KeyTypeOKP,
@@ -531,7 +531,7 @@ func Test_Key_derive_algorithm(t *testing.T) {
 	}
 
 	_, err = k.AlgorithmOrDefault()
-	assertEqualError(t, err, "unsupported curve \"P-256\" for key type OKP")
+	assertEqualError(t, err, `unsupported curve "P-256" for key type OKP`)
 
 	k = Key{
 		KeyType: KeyTypeOKP,
@@ -539,7 +539,7 @@ func Test_Key_derive_algorithm(t *testing.T) {
 	}
 
 	_, err = k.AlgorithmOrDefault()
-	assertEqualError(t, err, "unsupported curve \"X448\" for key type OKP")
+	assertEqualError(t, err, `unsupported curve "X448" for key type OKP`)
 
 	k = Key{
 		KeyType: KeyTypeOKP,
@@ -581,11 +581,11 @@ func Test_Key_signer_validation(t *testing.T) {
 
 	key.KeyType = KeyTypeEC2
 	_, err = key.Signer()
-	assertEqualError(t, err, "Key type mismatch for curve \"Ed25519\" (must be OKP, found EC2)")
+	assertEqualError(t, err, `Key type mismatch for curve "Ed25519" (must be OKP, found EC2)`)
 
 	key.Curve = CurveP256
 	_, err = key.Signer()
-	assertEqualError(t, err, "found algorithm \"EdDSA\" (expected \"ES256\")")
+	assertEqualError(t, err, `found algorithm "EdDSA" (expected "ES256")`)
 
 	key.KeyType = KeyTypeOKP
 	key.Algorithm = AlgorithmEd25519
@@ -600,11 +600,11 @@ func Test_Key_signer_validation(t *testing.T) {
 
 	key.Algorithm = AlgorithmES256
 	_, err = key.Signer()
-	assertEqualError(t, err, "found algorithm \"ES256\" (expected \"EdDSA\")")
+	assertEqualError(t, err, `found algorithm "ES256" (expected "EdDSA")`)
 
 	key.Curve = CurveX448
 	_, err = key.Signer()
-	assertEqualError(t, err, "unsupported curve \"X448\" for key type OKP")
+	assertEqualError(t, err, `unsupported curve "X448" for key type OKP`)
 }
 
 func Test_Key_verifier_validation(t *testing.T) {
@@ -619,7 +619,7 @@ func Test_Key_verifier_validation(t *testing.T) {
 
 	key.KeyType = KeyTypeEC2
 	_, err = key.Verifier()
-	assertEqualError(t, err, "Key type mismatch for curve \"Ed25519\" (must be OKP, found EC2)")
+	assertEqualError(t, err, `Key type mismatch for curve "Ed25519" (must be OKP, found EC2)`)
 
 	key.KeyType = KeyTypeOKP
 	key.KeyOps = []KeyOp{}
@@ -637,9 +637,9 @@ func Test_Key_crypto_keys(t *testing.T) {
 	}
 
 	_, err := k.PublicKey()
-	assertEqualError(t, err, "unexpected key type \"unknown key type value 7\"")
+	assertEqualError(t, err, `unexpected key type "unknown key type value 7"`)
 	_, err = k.PrivateKey()
-	assertEqualError(t, err, "unexpected key type \"unknown key type value 7\"")
+	assertEqualError(t, err, `unexpected key type "unknown key type value 7"`)
 
 	k = Key{
 		KeyType: KeyTypeOKP,
@@ -647,9 +647,9 @@ func Test_Key_crypto_keys(t *testing.T) {
 	}
 
 	_, err = k.PublicKey()
-	assertEqualError(t, err, "unsupported curve \"X448\" for key type OKP")
+	assertEqualError(t, err, `unsupported curve "X448" for key type OKP`)
 	_, err = k.PrivateKey()
-	assertEqualError(t, err, "unsupported curve \"X448\" for key type OKP")
+	assertEqualError(t, err, `unsupported curve "X448" for key type OKP`)
 
 	k = Key{
 		KeyType: KeyTypeOKP,

--- a/key_test.go
+++ b/key_test.go
@@ -666,3 +666,11 @@ func Test_Key_crypto_keys(t *testing.T) {
 	_, err = k.PrivateKey()
 	assertEqualError(t, err, ErrEC2NoPub.Error())
 }
+
+func Test_String(t *testing.T) {
+	// test string conversions not exercised by other test cases
+	assertEqual(t, "OKP", KeyTypeOKP.String())
+	assertEqual(t, "EC2", KeyTypeEC2.String())
+	assertEqual(t, "X25519", CurveX25519.String())
+	assertEqual(t, "Ed448", CurveEd448.String())
+}


### PR DESCRIPTION
A number of spec compliance fixes and interface adjustements for `COSE_Key`.

This address points 1, 3, 4, and 5 in https://github.com/veraison/go-cose/issues/151#issuecomment-1613196732