### PR TITLE
Convert key tests to tabular tests

### DIFF
--- a/key.go
+++ b/key.go
@@ -276,7 +276,10 @@ func NewOKPKey(alg Algorithm, x, d []byte) (*Key, error) {
 		X:         x,
 		D:         d,
 	}
-	return key, key.validate(KeyOpInvalid)
+	if err := key.validate(KeyOpInvalid); err != nil {
+		return nil, err
+	}
+	return key, nil
 }
 
 // NewEC2Key returns a Key created using the provided elliptic curve key
@@ -303,7 +306,10 @@ func NewEC2Key(alg Algorithm, x, y, d []byte) (*Key, error) {
 		Y:         y,
 		D:         d,
 	}
-	return key, key.validate(KeyOpInvalid)
+	if err := key.validate(KeyOpInvalid); err != nil {
+		return nil, err
+	}
+	return key, nil
 }
 
 // NewSymmetricKey returns a Key created using the provided Symmetric key

--- a/key.go
+++ b/key.go
@@ -315,11 +315,10 @@ func NewEC2Key(alg Algorithm, x, y, d []byte) (*Key, error) {
 // NewSymmetricKey returns a Key created using the provided Symmetric key
 // bytes.
 func NewSymmetricKey(k []byte) *Key {
-	key := &Key{
+	return &Key{
 		KeyType: KeyTypeSymmetric,
 		K:       k,
 	}
-	return key
 }
 
 // NewKeyFromPublic returns a Key created using the provided crypto.PublicKey.

--- a/key_test.go
+++ b/key_test.go
@@ -1,13 +1,11 @@
 package cose
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
-	"errors"
 	"math/big"
 	"reflect"
 	"testing"
@@ -103,16 +101,16 @@ func Test_KeyOp(t *testing.T) {
 	}
 }
 
-func Test_Key_UnmarshalCBOR(t *testing.T) {
-	tvs := []struct {
-		Name     string
-		Value    []byte
-		WantErr  string
-		Validate func(k *Key)
+func TestKey_UnmarshalCBOR(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    *Key
+		wantErr string
 	}{
 		{
-			Name: "ok OKP",
-			Value: []byte{
+			name: "ok OKP",
+			data: []byte{
 				0xa5,       // map (5)
 				0x01, 0x01, // kty: OKP
 				0x03, 0x27, //  alg: EdDSA w/ Ed25519
@@ -126,53 +124,50 @@ func Test_Key_UnmarshalCBOR(t *testing.T) {
 				0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
 				0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
 			},
-			WantErr: "",
-			Validate: func(k *Key) {
-				assertEqual(t, KeyTypeOKP, k.KeyType)
-				assertEqual(t, AlgorithmEd25519, k.Algorithm)
-				assertEqual(t, CurveEd25519, k.Curve)
-				assertEqual(t, []KeyOp{KeyOpVerify}, k.KeyOps)
-				assertEqual(t, []byte{
+			want: &Key{
+				KeyType:   KeyTypeOKP,
+				Algorithm: AlgorithmEd25519,
+				KeyOps:    []KeyOp{KeyOpVerify},
+				Curve:     CurveEd25519,
+				X: []byte{
 					0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3,
 					0x95, 0x09, 0xea, 0x5c, 0x15, 0xa2, 0x6b, 0xe9,
 					0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
 					0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
 				},
-					k.X,
-				)
-				assertEqual(t, []byte(nil), k.K)
 			},
+			wantErr: "",
 		},
 		{
-			Name: "invalid key type",
-			Value: []byte{
+			name: "invalid key type",
+			data: []byte{
 				0xa1,       // map (2)
 				0x01, 0x00, // kty: invalid
 			},
-			WantErr:  "invalid key type value 0",
-			Validate: nil,
+			want:    nil,
+			wantErr: "invalid key type value 0",
 		},
 		{
-			Name: "missing curve OKP",
-			Value: []byte{
+			name: "missing curve OKP",
+			data: []byte{
 				0xa1,       // map (2)
 				0x01, 0x01, // kty: OKP
 			},
-			WantErr:  "missing Curve parameter (required for OKP key type)",
-			Validate: nil,
+			want:    nil,
+			wantErr: "missing Curve parameter (required for OKP key type)",
 		},
 		{
-			Name: "missing curve EC2",
-			Value: []byte{
+			name: "missing curve EC2",
+			data: []byte{
 				0xa1,       // map (2)
 				0x01, 0x02, // kty: EC2
 			},
-			WantErr:  "missing Curve parameter (required for EC2 key type)",
-			Validate: nil,
+			want:    nil,
+			wantErr: "missing Curve parameter (required for EC2 key type)",
 		},
 		{
-			Name: "invalid curve OKP",
-			Value: []byte{
+			name: "invalid curve OKP",
+			data: []byte{
 				0xa3,       // map (3)
 				0x01, 0x01, // kty: OKP
 				0x20, 0x01, // curve: CurveP256
@@ -182,12 +177,12 @@ func Test_Key_UnmarshalCBOR(t *testing.T) {
 				0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
 				0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
 			},
-			WantErr:  `Key type mismatch for curve "P-256" (must be EC2, found OKP)`,
-			Validate: nil,
+			want:    nil,
+			wantErr: `Key type mismatch for curve "P-256" (must be EC2, found OKP)`,
 		},
 		{
-			Name: "invalid curve EC2",
-			Value: []byte{
+			name: "invalid curve EC2",
+			data: []byte{
 				0xa4,       // map (4)
 				0x01, 0x02, // kty: EC2
 				0x20, 0x06, // curve: CurveEd25519
@@ -202,52 +197,43 @@ func Test_Key_UnmarshalCBOR(t *testing.T) {
 				0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
 				0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
 			},
-			WantErr:  `Key type mismatch for curve "Ed25519" (must be OKP, found EC2)`,
-			Validate: nil,
+			want:    nil,
+			wantErr: `Key type mismatch for curve "Ed25519" (must be OKP, found EC2)`,
 		},
 		{
-			Name: "ok Symmetric",
-			Value: []byte{
-				0xa4,       // map (4)
+			name: "ok Symmetric",
+			data: []byte{
+				0xa2,       // map (2)
 				0x01, 0x04, // kty: Symmetric
-				0x03, 0x38, 0x24, //  alg: PS256
-				0x04,             // key ops
-				0x81,             // array (1)
-				0x02,             // verify
 				0x20, 0x58, 0x20, //  k: bytes(32)
 				0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3, // 32-byte value
 				0x95, 0x09, 0xea, 0x5c, 0x15, 0xa2, 0x6b, 0xe9,
 				0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
 				0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
 			},
-			WantErr: "",
-			Validate: func(k *Key) {
-				assertEqual(t, KeyTypeSymmetric, k.KeyType)
-				assertEqual(t, AlgorithmPS256, k.Algorithm)
-				assertEqual(t, int64(0), int64(k.Curve))
-				assertEqual(t, []KeyOp{KeyOpVerify}, k.KeyOps)
-				assertEqual(t, []byte{
+			want: &Key{
+				KeyType: KeyTypeSymmetric,
+				K: []byte{
 					0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3,
 					0x95, 0x09, 0xea, 0x5c, 0x15, 0xa2, 0x6b, 0xe9,
 					0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
 					0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
 				},
-					k.K,
-				)
 			},
+			wantErr: "",
 		},
 		{
-			Name: "missing K",
-			Value: []byte{
+			name: "missing K",
+			data: []byte{
 				0xa1,       // map (1)
 				0x01, 0x04, // kty: Symmetric
 			},
-			WantErr:  "missing K parameter (required for Symmetric key type)",
-			Validate: nil,
+			want:    nil,
+			wantErr: "missing K parameter (required for Symmetric key type)",
 		},
 		{
-			Name: "wrong algorithm",
-			Value: []byte{
+			name: "wrong algorithm",
+			data: []byte{
 				0xa4,       // map (3)
 				0x01, 0x01, // kty: OKP
 				0x03, 0x26, // alg: ECDSA w/ SHA-256
@@ -258,333 +244,630 @@ func Test_Key_UnmarshalCBOR(t *testing.T) {
 				0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
 				0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
 			},
-			WantErr:  `found algorithm "ES256" (expected "EdDSA")`,
-			Validate: nil,
+			want:    nil,
+			wantErr: `found algorithm "ES256" (expected "EdDSA")`,
 		},
 	}
 
-	for _, tv := range tvs {
-		t.Run(tv.Name, func(t *testing.T) {
-			var k Key
-
-			err := k.UnmarshalCBOR(tv.Value)
-			if tv.WantErr != "" {
-				if err == nil || err.Error() != tv.WantErr {
-					t.Errorf("Unexpected error: want %q, got %q", tv.WantErr, err)
-				}
-			} else {
-				tv.Validate(&k)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := new(Key)
+			err := got.UnmarshalCBOR(tt.data)
+			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
+				t.Errorf("Key.UnmarshalCBOR() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Key.UnmarshalCBOR() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func Test_Key_MarshalCBOR(t *testing.T) {
-	k := Key{
-		KeyType: KeyTypeOKP,
-		KeyOps:  []KeyOp{KeyOpVerify, KeyOpEncrypt},
-		X: []byte{
-			0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3,
-			0x95, 0x09, 0xea, 0x5c, 0x15, 0xa2, 0x6b, 0xe9,
-			0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
-			0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
+func TestKey_MarshalCBOR(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     *Key
+		want    []byte
+		wantErr string
+	}{
+		{
+			name: "OKP",
+			key: &Key{
+				KeyType: KeyTypeOKP,
+				KeyOps:  []KeyOp{KeyOpVerify, KeyOpEncrypt},
+				X: []byte{
+					0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3,
+					0x95, 0x09, 0xea, 0x5c, 0x15, 0xa2, 0x6b, 0xe9,
+					0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
+					0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
+				},
+				Algorithm: AlgorithmEd25519,
+				Curve:     CurveEd25519,
+			},
+			want: []byte{
+				0xa5,       // map (5)
+				0x01, 0x01, // kty: OKP
+				0x03, 0x27, //  alg: EdDSA w/ Ed25519
+				0x04,       // key ops
+				0x82,       // array (2)
+				0x02, 0x03, // verify, encrypt
+				0x20, 0x06, // curve: Ed25519
+				0x21, 0x58, 0x20, //  x-coordinate: bytes(32)
+				0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3, // 32-byte value
+				0x95, 0x09, 0xea, 0x5c, 0x15, 0xa2, 0x6b, 0xe9,
+				0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
+				0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
+			},
+			wantErr: "",
+		}, {
+			name: "Symmetric",
+			key: &Key{
+				KeyType: KeyTypeSymmetric,
+				K: []byte{
+					0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3,
+					0x95, 0x09, 0xea, 0x5c, 0x15, 0xa2, 0x6b, 0xe9,
+					0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
+					0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
+				},
+			},
+			want: []byte{
+				0xa2,       // map (2)
+				0x01, 0x04, // kty: Symmetric
+				0x20, 0x58, 0x20, //  K: bytes(32)
+				0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3, // 32-byte value
+				0x95, 0x09, 0xea, 0x5c, 0x15, 0xa2, 0x6b, 0xe9,
+				0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
+				0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
+			},
+			wantErr: "",
+		}, {
+			name:    "unknown key type",
+			key:     &Key{KeyType: 42},
+			want:    nil,
+			wantErr: `invalid key type: "unknown key type value 42"`,
 		},
-		Algorithm: AlgorithmEd25519,
-		Curve:     CurveEd25519,
 	}
-
-	data, err := k.MarshalCBOR()
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-		return
-	}
-	expected := []byte{
-		0xa5,       // map (5)
-		0x01, 0x01, // kty: OKP
-		0x03, 0x27, //  alg: EdDSA w/ Ed25519
-		0x04,       // key ops
-		0x82,       // array (2)
-		0x02, 0x03, // verify, encrypt
-		0x20, 0x06, // curve: Ed25519
-		0x21, 0x58, 0x20, //  x-coordinate: bytes(32)
-		0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3, // 32-byte value
-		0x95, 0x09, 0xea, 0x5c, 0x15, 0xa2, 0x6b, 0xe9,
-		0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
-		0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
-	}
-	if !bytes.Equal(expected, data) {
-		t.Errorf("Bad marshal: %v", data)
-	}
-
-	k = Key{
-		KeyType: KeyTypeSymmetric,
-		K: []byte{
-			0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3,
-			0x95, 0x09, 0xea, 0x5c, 0x15, 0xa2, 0x6b, 0xe9,
-			0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
-			0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
-		},
-	}
-
-	data, err = k.MarshalCBOR()
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-		return
-	}
-	expected = []byte{
-		0xa2,       // map (2)
-		0x01, 0x04, // kty: Symmetric
-		0x20, 0x58, 0x20, //  K: bytes(32)
-		0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3, // 32-byte value
-		0x95, 0x09, 0xea, 0x5c, 0x15, 0xa2, 0x6b, 0xe9,
-		0x49, 0xe3, 0x88, 0x07, 0xa5, 0xc2, 0x6e, 0xf9,
-		0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
-	}
-	if !bytes.Equal(expected, data) {
-		t.Errorf("Bad marshal: %v", data)
-	}
-
-	k.KeyType = KeyType(42)
-	_, err = k.MarshalCBOR()
-	wantErr := `invalid key type: "unknown key type value 42"`
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("Unexpected error: want %q, got %q", wantErr, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.key.MarshalCBOR()
+			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
+				t.Errorf("Key.MarshalCBOR() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Key.MarshalCBOR() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
-func Test_Key_Create_and_Validate(t *testing.T) {
+func TestNewOKPKey(t *testing.T) {
 	x := []byte{
 		0x30, 0xa0, 0x42, 0x4c, 0xd2, 0x1c, 0x29, 0x44,
 		0x83, 0x8a, 0x2d, 0x75, 0xc9, 0x2b, 0x37, 0xe7,
 		0x6e, 0xa2, 0x0d, 0x9f, 0x00, 0x89, 0x3a, 0x3b,
 		0x4e, 0xee, 0x8a, 0x3c, 0x0a, 0xaf, 0xec, 0x3e,
 	}
-
-	y := []byte{
+	d := []byte{
 		0xe0, 0x4b, 0x65, 0xe9, 0x24, 0x56, 0xd9, 0x88,
 		0x8b, 0x52, 0xb3, 0x79, 0xbd, 0xfb, 0xd5, 0x1e,
 		0xe8, 0x69, 0xef, 0x1f, 0x0f, 0xc6, 0x5b, 0x66,
 		0x59, 0x69, 0x5b, 0x6c, 0xce, 0x08, 0x17, 0x23,
 	}
-
-	key, err := NewOKPKey(AlgorithmEd25519, x, nil)
-	requireNoError(t, err)
-	assertEqual(t, KeyTypeOKP, key.KeyType)
-	assertEqual(t, x, key.X)
-
-	_, err = NewOKPKey(AlgorithmES256, x, nil)
-	assertEqualError(t, err, `unsupported algorithm "ES256"`)
-
-	_, err = NewEC2Key(AlgorithmEd25519, x, y, nil)
-	assertEqualError(t, err, `unsupported algorithm "EdDSA"`)
-
-	key, err = NewEC2Key(AlgorithmES256, x, y, nil)
-	requireNoError(t, err)
-	assertEqual(t, KeyTypeEC2, key.KeyType)
-	assertEqual(t, x, key.X)
-	assertEqual(t, y, key.Y)
-
-	key = NewSymmetricKey(x)
-	assertEqual(t, x, key.K)
-
-	_, err = NewKeyFromPublic(crypto.PublicKey([]byte{0xde, 0xad, 0xbe, 0xef}))
-	assertEqualError(t, err, "invalid public key")
-
-	_, err = NewKeyFromPrivate(crypto.PublicKey([]byte{0xde, 0xad, 0xbe, 0xef}))
-	assertEqualError(t, err, "invalid private key")
-}
-
-func Test_Key_ed25519_signature_round_trip(t *testing.T) {
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
-	requireNoError(t, err)
-
-	key, err := NewKeyFromPrivate(priv)
-	requireNoError(t, err)
-	assertEqual(t, AlgorithmEd25519, key.Algorithm)
-	assertEqual(t, CurveEd25519, key.Curve)
-	assertEqual(t, pub, key.X)
-	assertEqual(t, priv[:32], key.D)
-
-	signer, err := key.Signer()
-	requireNoError(t, err)
-
-	message := []byte("foo bar")
-	sig, err := signer.Sign(rand.Reader, message)
-	requireNoError(t, err)
-
-	key, err = NewKeyFromPublic(pub)
-	requireNoError(t, err)
-
-	assertEqual(t, AlgorithmEd25519, key.Algorithm)
-	assertEqual(t, CurveEd25519, key.Curve)
-	assertEqual(t, pub, key.X)
-
-	verifier, err := key.Verifier()
-	requireNoError(t, err)
-
-	err = verifier.Verify(message, sig)
-	requireNoError(t, err)
-}
-
-func Test_Key_ecdsa_signature_round_trip(t *testing.T) {
-	for _, tv := range []struct {
-		EC        elliptic.Curve
-		Curve     Curve
-		Algorithm Algorithm
+	type args struct {
+		alg Algorithm
+		x   []byte
+		d   []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Key
+		wantErr string
 	}{
-		{elliptic.P256(), CurveP256, AlgorithmES256},
-		{elliptic.P384(), CurveP384, AlgorithmES384},
-		{elliptic.P521(), CurveP521, AlgorithmES512},
-	} {
-		t.Run(tv.Curve.String(), func(t *testing.T) {
-			priv, err := ecdsa.GenerateKey(tv.EC, rand.Reader)
-			requireNoError(t, err)
-
-			key, err := NewKeyFromPrivate(priv)
-			requireNoError(t, err)
-			assertEqual(t, tv.Curve, key.Curve)
-			assertEqual(t, priv.X.Bytes(), key.X)
-			assertEqual(t, priv.Y.Bytes(), key.Y)
-			assertEqual(t, priv.D.Bytes(), key.D)
-
-			signer, err := key.Signer()
-			requireNoError(t, err)
-
-			message := []byte("foo bar")
-			sig, err := signer.Sign(rand.Reader, message)
-			requireNoError(t, err)
-
-			pub := priv.Public()
-
-			key, err = NewKeyFromPublic(pub)
-			requireNoError(t, err)
-
-			assertEqual(t, tv.Curve, key.Curve)
-			assertEqual(t, priv.X.Bytes(), key.X)
-			assertEqual(t, priv.Y.Bytes(), key.Y)
-
-			verifier, err := key.Verifier()
-			requireNoError(t, err)
-
-			err = verifier.Verify(message, sig)
-			requireNoError(t, err)
+		{
+			name: "valid", args: args{AlgorithmEd25519, x, d},
+			want: &Key{
+				KeyType:   KeyTypeOKP,
+				Algorithm: AlgorithmEd25519,
+				Curve:     CurveEd25519,
+				X:         x,
+				D:         d,
+			},
+			wantErr: "",
+		}, {
+			name: "invalid alg", args: args{Algorithm(-100), x, d},
+			want:    nil,
+			wantErr: `unsupported algorithm "unknown algorithm value -100"`,
+		}, {
+			name: "x and d missing", args: args{AlgorithmEd25519, nil, nil},
+			want:    nil,
+			wantErr: ErrInvalidKey.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewOKPKey(tt.args.alg, tt.args.x, tt.args.d)
+			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
+				t.Errorf("NewOKPKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewOKPKey() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }
 
-func Test_Key_derive_algorithm(t *testing.T) {
-	k := Key{
-		KeyType: KeyTypeEC2,
-		Curve:   CurveEd25519,
+func TestNewEC2Key(t *testing.T) {
+	x := []byte{1, 2, 3}
+	y := []byte{4, 5, 6}
+	d := []byte{7, 8, 9}
+	type args struct {
+		alg Algorithm
+		x   []byte
+		y   []byte
+		d   []byte
 	}
-
-	_, err := k.AlgorithmOrDefault()
-	assertEqualError(t, err, `unsupported curve "Ed25519" for key type EC2`)
-
-	k = Key{
-		KeyType: KeyTypeOKP,
-		Curve:   CurveP256,
+	tests := []struct {
+		name    string
+		args    args
+		want    *Key
+		wantErr string
+	}{
+		{
+			name: "valid ES256", args: args{AlgorithmES256, x, y, d},
+			want: &Key{
+				KeyType:   KeyTypeEC2,
+				Algorithm: AlgorithmES256,
+				Curve:     CurveP256,
+				X:         x,
+				Y:         y,
+				D:         d,
+			},
+			wantErr: "",
+		}, {
+			name: "valid ES384", args: args{AlgorithmES384, x, y, d},
+			want: &Key{
+				KeyType:   KeyTypeEC2,
+				Algorithm: AlgorithmES384,
+				Curve:     CurveP384,
+				X:         x,
+				Y:         y,
+				D:         d,
+			},
+			wantErr: "",
+		}, {
+			name: "valid ES521", args: args{AlgorithmES512, x, y, d},
+			want: &Key{
+				KeyType:   KeyTypeEC2,
+				Algorithm: AlgorithmES512,
+				Curve:     CurveP521,
+				X:         x,
+				Y:         y,
+				D:         d,
+			},
+			wantErr: "",
+		}, {
+			name: "invalid alg", args: args{Algorithm(-100), x, y, d},
+			want:    nil,
+			wantErr: `unsupported algorithm "unknown algorithm value -100"`,
+		}, {
+			name: "x, y and d missing", args: args{AlgorithmES512, nil, nil, nil},
+			want:    nil,
+			wantErr: ErrInvalidKey.Error(),
+		},
 	}
-
-	_, err = k.AlgorithmOrDefault()
-	assertEqualError(t, err, `unsupported curve "P-256" for key type OKP`)
-
-	k = Key{
-		KeyType: KeyTypeOKP,
-		Curve:   CurveX448,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewEC2Key(tt.args.alg, tt.args.x, tt.args.y, tt.args.d)
+			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
+				t.Errorf("NewEC2Key() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewEC2Key() = %v, want %v", got, tt.want)
+			}
+		})
 	}
-
-	_, err = k.AlgorithmOrDefault()
-	assertEqualError(t, err, `unsupported curve "X448" for key type OKP`)
-
-	k = Key{
-		KeyType: KeyTypeOKP,
-		Curve:   CurveEd25519,
-	}
-
-	alg, err := k.AlgorithmOrDefault()
-	requireNoError(t, err)
-	assertEqual(t, AlgorithmEd25519, alg)
 }
 
-func Test_NewKeyFrom(t *testing.T) {
-	pub := ecdsa.PublicKey{Curve: *new(elliptic.Curve), X: new(big.Int), Y: new(big.Int)}
-	_, err := NewKeyFromPublic(&pub)
-	assertEqualError(t, err, "unsupported curve: <nil>")
-
-	priv := ecdsa.PrivateKey{PublicKey: pub, D: new(big.Int)}
-	_, err = NewKeyFromPrivate(&priv)
-	assertEqualError(t, err, "unsupported curve: <nil>")
+func TestKey_SignRoundtrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		newKey func() (crypto.PrivateKey, error)
+	}{
+		{
+			"P-256", func() (crypto.PrivateKey, error) {
+				return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			},
+		}, {
+			"P-384", func() (crypto.PrivateKey, error) {
+				return ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+			},
+		}, {
+			"P-521", func() (crypto.PrivateKey, error) {
+				return ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+			},
+		}, {
+			"ED25519", func() (crypto.PrivateKey, error) {
+				_, priv, err := ed25519.GenerateKey(rand.Reader)
+				return priv, err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			priv, err := tt.newKey()
+			if err != nil {
+				t.Fatal(err)
+			}
+			key, err := NewKeyFromPrivate(priv)
+			if err != nil {
+				t.Fatal(err)
+			}
+			signer, err := key.Signer()
+			if err != nil {
+				t.Fatal(err)
+			}
+			message := []byte("foo bar")
+			sig, err := signer.Sign(rand.Reader, message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			verifier, err := key.Verifier()
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = verifier.Verify(message, sig)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
 }
 
-func Test_algorithmFromEllipticCurve(t *testing.T) {
-	alg := algorithmFromEllipticCurve(*new(elliptic.Curve))
-	assertEqual(t, alg, AlgorithmInvalid)
+func TestKey_AlgorithmOrDefault(t *testing.T) {
+	tests := []struct {
+		name    string
+		k       *Key
+		want    Algorithm
+		wantErr string
+	}{
+		{
+			"custom",
+			&Key{Algorithm: -1000},
+			-1000,
+			"",
+		},
+		{
+			"OKP-Ed25519",
+			&Key{
+				KeyType: KeyTypeOKP,
+				Curve:   CurveEd25519,
+			},
+			AlgorithmEd25519,
+			"",
+		},
+		{
+			"OKP-P256",
+			&Key{
+				KeyType: KeyTypeOKP,
+				Curve:   CurveP256,
+			},
+			AlgorithmInvalid,
+			`unsupported curve "P-256" for key type OKP`,
+		},
+		{
+			"EC2-P256",
+			&Key{
+				KeyType: KeyTypeEC2,
+				Curve:   CurveP256,
+			},
+			AlgorithmES256,
+			"",
+		},
+		{
+			"EC2-P384",
+			&Key{
+				KeyType: KeyTypeEC2,
+				Curve:   CurveP384,
+			},
+			AlgorithmES384,
+			"",
+		},
+		{
+			"EC2-P521",
+			&Key{
+				KeyType: KeyTypeEC2,
+				Curve:   CurveP521,
+			},
+			AlgorithmES512,
+			"",
+		},
+		{
+			"EC2-Ed25519",
+			&Key{
+				KeyType: KeyTypeEC2,
+				Curve:   CurveEd25519,
+			},
+			AlgorithmInvalid,
+			`unsupported curve "Ed25519" for key type EC2`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.k.AlgorithmOrDefault()
+			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
+				t.Errorf("Key.AlgorithmOrDefault() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Key.AlgorithmOrDefault() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
-func Test_Key_signer_validation(t *testing.T) {
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
-	requireNoError(t, err)
+func TestNewKeyFromPrivate(t *testing.T) {
+	tests := []struct {
+		name    string
+		k       crypto.PrivateKey
+		want    *Key
+		wantErr string
+	}{
+		{
+			"ecdsa", &ecdsa.PrivateKey{
+				PublicKey: ecdsa.PublicKey{Curve: elliptic.P256(), X: big.NewInt(1), Y: big.NewInt(2)},
+				D:         big.NewInt(3),
+			}, &Key{
+				Algorithm: AlgorithmES256,
+				KeyType:   KeyTypeEC2,
+				Curve:     CurveP256,
+				X:         big.NewInt(1).Bytes(),
+				Y:         big.NewInt(2).Bytes(),
+				D:         big.NewInt(3).Bytes(),
+			},
+			"",
+		},
+		{
+			"ecdsa invalid", &ecdsa.PrivateKey{
+				PublicKey: ecdsa.PublicKey{Curve: *new(elliptic.Curve), X: big.NewInt(1), Y: big.NewInt(2)},
+				D:         big.NewInt(3),
+			},
+			nil,
+			"unsupported curve: <nil>",
+		},
+		{
+			"ed25519", ed25519.PrivateKey{
+				1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			},
+			&Key{
+				Algorithm: AlgorithmEd25519, KeyType: KeyTypeOKP, Curve: CurveEd25519,
+				X: []byte{4, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				D: []byte{1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+			"",
+		},
+		{
+			"invalid key", ed25519.PublicKey{1, 2, 3},
+			nil,
+			ErrInvalidPrivKey.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewKeyFromPrivate(tt.k)
+			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
+				t.Errorf("NewKeyFromPrivate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewKeyFromPrivate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
-	key, err := NewKeyFromPublic(pub)
-	requireNoError(t, err)
+func TestNewKeyFromPublic(t *testing.T) {
+	tests := []struct {
+		name    string
+		k       crypto.PublicKey
+		want    *Key
+		wantErr string
+	}{
+		{
+			"ecdsa", &ecdsa.PublicKey{Curve: elliptic.P256(), X: big.NewInt(1), Y: big.NewInt(2)},
+			&Key{
+				Algorithm: AlgorithmES256,
+				KeyType:   KeyTypeEC2,
+				Curve:     CurveP256,
+				X:         big.NewInt(1).Bytes(),
+				Y:         big.NewInt(2).Bytes(),
+			},
+			"",
+		},
+		{
+			"ecdsa invalid", &ecdsa.PublicKey{Curve: *new(elliptic.Curve), X: big.NewInt(1), Y: big.NewInt(2)},
+			nil,
+			"unsupported curve: <nil>",
+		},
+		{
+			"ed25519", ed25519.PublicKey{1, 2, 3},
+			&Key{Algorithm: AlgorithmEd25519, KeyType: KeyTypeOKP, Curve: CurveEd25519, X: []byte{1, 2, 3}},
+			"",
+		},
+		{
+			"invalid key", ed25519.PrivateKey{1, 2, 3, 1, 2, 3},
+			nil,
+			ErrInvalidPubKey.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewKeyFromPublic(tt.k)
+			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
+				t.Errorf("NewKeyFromPublic() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewKeyFromPublic() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
-	_, err = key.Signer()
-	assertEqualError(t, err, ErrNotPrivKey.Error())
-
-	key, err = NewKeyFromPrivate(priv)
-	requireNoError(t, err)
-
-	key.KeyType = KeyTypeEC2
-	_, err = key.Signer()
-	assertEqualError(t, err, `Key type mismatch for curve "Ed25519" (must be OKP, found EC2)`)
-
-	key.Curve = CurveP256
-	_, err = key.Signer()
-	assertEqualError(t, err, `found algorithm "EdDSA" (expected "ES256")`)
-
-	key.KeyType = KeyTypeOKP
-	key.Algorithm = AlgorithmEd25519
-	key.Curve = CurveEd25519
-	key.KeyOps = []KeyOp{}
-	_, err = key.Signer()
-	assertEqualError(t, err, ErrOpNotSupported.Error())
-
-	key.KeyOps = []KeyOp{KeyOpSign}
-	_, err = key.Signer()
-	requireNoError(t, err)
-
-	key.Algorithm = AlgorithmES256
-	_, err = key.Signer()
-	assertEqualError(t, err, `found algorithm "ES256" (expected "EdDSA")`)
-
-	key.Curve = CurveX448
-	_, err = key.Signer()
-	assertEqualError(t, err, `unsupported curve "X448" for key type OKP`)
+func TestKey_Signer(t *testing.T) {
+	x := []byte{0xde, 0xad, 0xbe, 0xef}
+	d := []byte{0xde, 0xad, 0xbe, 0xef}
+	tests := []struct {
+		name    string
+		k       *Key
+		wantAlg Algorithm
+		wantErr string
+	}{
+		{
+			"without algorithm", &Key{
+				KeyType: KeyTypeOKP,
+				KeyOps:  []KeyOp{KeyOpSign},
+				Curve:   CurveEd25519,
+				X:       x,
+				D:       d,
+			},
+			AlgorithmEd25519,
+			"",
+		},
+		{
+			"without key_ops", &Key{
+				KeyType:   KeyTypeOKP,
+				Algorithm: AlgorithmEd25519,
+				Curve:     CurveEd25519,
+				X:         x,
+				D:         d,
+			},
+			AlgorithmEd25519,
+			"",
+		},
+		{
+			"invalid algorithm", &Key{
+				KeyType: KeyTypeOKP,
+				Curve:   CurveP256,
+				X:       x,
+				D:       d,
+			},
+			AlgorithmInvalid,
+			`Key type mismatch for curve "P-256" (must be EC2, found OKP)`,
+		},
+		{
+			"can't sign", &Key{
+				KeyType: KeyTypeOKP,
+				Curve:   CurveEd25519,
+				KeyOps:  []KeyOp{KeyOpVerify},
+				X:       x,
+				D:       d,
+			},
+			AlgorithmInvalid,
+			ErrOpNotSupported.Error(),
+		},
+		{
+			"unsupported key", &Key{
+				KeyType: KeyTypeSymmetric,
+				KeyOps:  []KeyOp{KeyOpSign},
+				K:       x,
+				D:       d,
+			},
+			AlgorithmInvalid,
+			`unexpected key type "Symmetric"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := tt.k.Signer()
+			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
+				t.Errorf("Key.Signer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil {
+				if got := v.Algorithm(); got != tt.wantAlg {
+					t.Errorf("Key.Signer().Algorithm() = %v, want %v", got, tt.wantAlg)
+				}
+			}
+		})
+	}
 }
 
 func TestKey_Verifier(t *testing.T) {
-	pub, _, err := ed25519.GenerateKey(rand.Reader)
-	requireNoError(t, err)
-
-	key, err := NewKeyFromPublic(pub)
-	requireNoError(t, err)
-
-	_, err = key.Verifier()
-	requireNoError(t, err)
-
-	key.KeyType = KeyTypeEC2
-	_, err = key.Verifier()
-	assertEqualError(t, err, ErrEC2NoPub.Error())
-
-	key.KeyType = KeyTypeOKP
-	key.KeyOps = []KeyOp{}
-	_, err = key.Verifier()
-	assertEqualError(t, err, ErrOpNotSupported.Error())
-
-	key.KeyOps = []KeyOp{KeyOpVerify}
-	_, err = key.Verifier()
-	requireNoError(t, err)
+	x := []byte{0xde, 0xad, 0xbe, 0xef}
+	tests := []struct {
+		name    string
+		k       *Key
+		wantAlg Algorithm
+		wantErr string
+	}{
+		{
+			"without algorithm", &Key{
+				KeyType: KeyTypeOKP,
+				KeyOps:  []KeyOp{KeyOpVerify},
+				Curve:   CurveEd25519,
+				X:       x,
+			},
+			AlgorithmEd25519,
+			"",
+		},
+		{
+			"without key_ops", &Key{
+				KeyType:   KeyTypeOKP,
+				Algorithm: AlgorithmEd25519,
+				Curve:     CurveEd25519,
+				X:         x,
+			},
+			AlgorithmEd25519,
+			"",
+		},
+		{
+			"invalid algorithm", &Key{
+				KeyType: KeyTypeOKP,
+				Curve:   CurveP256,
+				X:       x,
+			},
+			AlgorithmInvalid,
+			`Key type mismatch for curve "P-256" (must be EC2, found OKP)`,
+		},
+		{
+			"can't verify", &Key{
+				KeyType: KeyTypeOKP,
+				Curve:   CurveEd25519,
+				KeyOps:  []KeyOp{KeyOpSign},
+				X:       x,
+			},
+			AlgorithmInvalid,
+			ErrOpNotSupported.Error(),
+		},
+		{
+			"unsupported key", &Key{
+				KeyType: KeyTypeSymmetric,
+				KeyOps:  []KeyOp{KeyOpVerify},
+				K:       x,
+			},
+			AlgorithmInvalid,
+			`unexpected key type "Symmetric"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := tt.k.Verifier()
+			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
+				t.Errorf("Key.Verifier() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil {
+				if got := v.Algorithm(); got != tt.wantAlg {
+					t.Errorf("Key.Verifier().Algorithm() = %v, want %v", got, tt.wantAlg)
+				}
+			}
+		})
+	}
 }
 
 func TestKey_PrivateKey(t *testing.T) {
@@ -595,7 +878,7 @@ func TestKey_PrivateKey(t *testing.T) {
 		name    string
 		k       *Key
 		want    crypto.PrivateKey
-		wantErr error
+		wantErr string
 	}{
 		{
 			"CurveEd25519", &Key{
@@ -608,7 +891,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				d[0], d[1], d[2], d[3], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 				x[0], x[1], x[2], x[3], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 			},
-			nil,
+			"",
 		}, {
 			"CurveP256", &Key{
 				KeyType: KeyTypeEC2,
@@ -625,7 +908,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 				D: new(big.Int).SetBytes(d),
 			},
-			nil,
+			"",
 		}, {
 			"CurveP384", &Key{
 				KeyType: KeyTypeEC2,
@@ -642,7 +925,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 				D: new(big.Int).SetBytes(d),
 			},
-			nil,
+			"",
 		}, {
 			"CurveP521", &Key{
 				KeyType: KeyTypeEC2,
@@ -659,13 +942,13 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 				D: new(big.Int).SetBytes(d),
 			},
-			nil,
+			"",
 		}, {
 			"unknown key type", &Key{
 				KeyType: KeyType(7),
 			},
 			nil,
-			errors.New(`unexpected key type "unknown key type value 7"`),
+			`unexpected key type "unknown key type value 7"`,
 		}, {
 			"OKP missing X", &Key{
 				KeyType: KeyTypeOKP,
@@ -673,7 +956,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				D:       d,
 			},
 			nil,
-			ErrOKPNoPub,
+			ErrOKPNoPub.Error(),
 		}, {
 			"OKP missing D", &Key{
 				KeyType: KeyTypeOKP,
@@ -681,7 +964,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				X:       x,
 			},
 			nil,
-			ErrNotPrivKey,
+			ErrNotPrivKey.Error(),
 		}, {
 			"OKP unknown curve", &Key{
 				KeyType: KeyTypeOKP,
@@ -690,7 +973,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				D:       d,
 			},
 			nil,
-			errors.New(`unsupported curve "unknown curve value 70" for key type OKP`),
+			`unsupported curve "unknown curve value 70" for key type OKP`,
 		}, {
 			"EC2 missing X", &Key{
 				KeyType: KeyTypeEC2,
@@ -699,7 +982,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				D:       d,
 			},
 			nil,
-			ErrEC2NoPub,
+			ErrEC2NoPub.Error(),
 		}, {
 			"EC2 missing Y", &Key{
 				KeyType: KeyTypeEC2,
@@ -708,7 +991,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				D:       d,
 			},
 			nil,
-			ErrEC2NoPub,
+			ErrEC2NoPub.Error(),
 		}, {
 			"EC2 missing D", &Key{
 				KeyType: KeyTypeEC2,
@@ -717,7 +1000,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				Y:       y,
 			},
 			nil,
-			ErrNotPrivKey,
+			ErrNotPrivKey.Error(),
 		}, {
 			"EC2 unknown curve", &Key{
 				KeyType: KeyTypeEC2,
@@ -727,13 +1010,13 @@ func TestKey_PrivateKey(t *testing.T) {
 				D:       d,
 			},
 			nil,
-			errors.New(`unsupported curve "unknown curve value 70" for key type EC2`),
+			`unsupported curve "unknown curve value 70" for key type EC2`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.k.PrivateKey()
-			if err != nil && err.Error() != tt.wantErr.Error() {
+			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
 				t.Errorf("Key.PrivateKey() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
@@ -751,7 +1034,7 @@ func TestKey_PublicKey(t *testing.T) {
 		name    string
 		k       *Key
 		want    crypto.PublicKey
-		wantErr error
+		wantErr string
 	}{
 		{
 			"CurveEd25519", &Key{
@@ -760,7 +1043,7 @@ func TestKey_PublicKey(t *testing.T) {
 				X:       x,
 			},
 			ed25519.PublicKey(x),
-			nil,
+			"",
 		}, {
 			"CurveP256", &Key{
 				KeyType: KeyTypeEC2,
@@ -773,7 +1056,7 @@ func TestKey_PublicKey(t *testing.T) {
 				X:     new(big.Int).SetBytes(x),
 				Y:     new(big.Int).SetBytes(y),
 			},
-			nil,
+			"",
 		}, {
 			"CurveP384", &Key{
 				KeyType: KeyTypeEC2,
@@ -786,7 +1069,7 @@ func TestKey_PublicKey(t *testing.T) {
 				X:     new(big.Int).SetBytes(x),
 				Y:     new(big.Int).SetBytes(y),
 			},
-			nil,
+			"",
 		}, {
 			"CurveP521", &Key{
 				KeyType: KeyTypeEC2,
@@ -799,20 +1082,20 @@ func TestKey_PublicKey(t *testing.T) {
 				X:     new(big.Int).SetBytes(x),
 				Y:     new(big.Int).SetBytes(y),
 			},
-			nil,
+			"",
 		}, {
 			"unknown key type", &Key{
 				KeyType: KeyType(7),
 			},
 			nil,
-			errors.New(`unexpected key type "unknown key type value 7"`),
+			`unexpected key type "unknown key type value 7"`,
 		}, {
 			"OKP missing X", &Key{
 				KeyType: KeyTypeOKP,
 				Curve:   CurveEd25519,
 			},
 			nil,
-			ErrOKPNoPub,
+			ErrOKPNoPub.Error(),
 		}, {
 			"OKP unknown curve", &Key{
 				KeyType: KeyTypeOKP,
@@ -821,7 +1104,7 @@ func TestKey_PublicKey(t *testing.T) {
 				Y:       y,
 			},
 			nil,
-			errors.New(`unsupported curve "unknown curve value 70" for key type OKP`),
+			`unsupported curve "unknown curve value 70" for key type OKP`,
 		}, {
 			"EC2 missing X", &Key{
 				KeyType: KeyTypeEC2,
@@ -829,7 +1112,7 @@ func TestKey_PublicKey(t *testing.T) {
 				Y:       y,
 			},
 			nil,
-			ErrEC2NoPub,
+			ErrEC2NoPub.Error(),
 		}, {
 			"EC2 missing Y", &Key{
 				KeyType: KeyTypeEC2,
@@ -837,7 +1120,7 @@ func TestKey_PublicKey(t *testing.T) {
 				X:       x,
 			},
 			nil,
-			ErrEC2NoPub,
+			ErrEC2NoPub.Error(),
 		}, {
 			"EC2 unknown curve", &Key{
 				KeyType: KeyTypeEC2,
@@ -846,13 +1129,13 @@ func TestKey_PublicKey(t *testing.T) {
 				Y:       y,
 			},
 			nil,
-			errors.New(`unsupported curve "unknown curve value 70" for key type EC2`),
+			`unsupported curve "unknown curve value 70" for key type EC2`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.k.PublicKey()
-			if err != nil && err.Error() != tt.wantErr.Error() {
+			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
 				t.Errorf("Key.PublicKey() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
@@ -863,10 +1146,38 @@ func TestKey_PublicKey(t *testing.T) {
 	}
 }
 
-func Test_String(t *testing.T) {
+func TestKeyType_String(t *testing.T) {
 	// test string conversions not exercised by other test cases
-	assertEqual(t, "OKP", KeyTypeOKP.String())
-	assertEqual(t, "EC2", KeyTypeEC2.String())
-	assertEqual(t, "X25519", CurveX25519.String())
-	assertEqual(t, "Ed448", CurveEd448.String())
+	tests := []struct {
+		kt   KeyType
+		want string
+	}{
+		{KeyTypeOKP, "OKP"},
+		{KeyTypeEC2, "EC2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.kt.String(); got != tt.want {
+				t.Errorf("KeyType.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCurve_String(t *testing.T) {
+	// test string conversions not exercised by other test cases
+	tests := []struct {
+		kt   Curve
+		want string
+	}{
+		{CurveX25519, "X25519"},
+		{CurveEd448, "Ed448"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.kt.String(); got != tt.want {
+				t.Errorf("Curve.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/key_test.go
+++ b/key_test.go
@@ -473,6 +473,29 @@ func TestNewEC2Key(t *testing.T) {
 	}
 }
 
+func TestNewSymmetricKey(t *testing.T) {
+	type args struct {
+		k []byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Key
+	}{
+		{"valid", args{[]byte{1, 2, 3}}, &Key{
+			KeyType: KeyTypeSymmetric,
+			K:       []byte{1, 2, 3},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewSymmetricKey(tt.args.k); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewSymmetricKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestKey_SignRoundtrip(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/key_test.go
+++ b/key_test.go
@@ -514,7 +514,7 @@ func TestKey_SignRoundtrip(t *testing.T) {
 				return ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 			},
 		}, {
-			"ED25519", func() (crypto.PrivateKey, error) {
+			"Ed25519", func() (crypto.PrivateKey, error) {
 				_, priv, err := ed25519.GenerateKey(rand.Reader)
 				return priv, err
 			},


### PR DESCRIPTION
This PR contains converts all COSE_Key-related tests to tabular tests, making those test more similar to the COSE_Sign related tests. Also, IMO, tabular tests make it easier to understand what is being tested, as they don't depend on reusing and mutating inputs but on explicit and clearly definid inputs and outputs.

There is just one behavior change in this PR: `NewEC2Key` and `NewOKPKey` return a nil key if the validation fails, together with the corresponding error. Returning nil objects when there is an error instead is more idiomatic and less error prone.

This will also facilitate testing the API redesign that I'll submit as part of #151.