### PR TITLE
Deprecate AlgorithmEd25519 and provide AlgorithmEdDSA instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ These are the required packages for each built-in cose.Algorithm:
 
 - cose.AlgorithmPS256, cose.AlgorithmES256: `crypto/sha256`
 - cose.AlgorithmPS384, cose.AlgorithmPS512, cose.AlgorithmES384, cose.AlgorithmES512: `crypto/sha512`
-- cose.AlgorithmEd25519: none
+- cose.AlgorithmEdDSA: none
 
 ## Features
 

--- a/algorithm.go
+++ b/algorithm.go
@@ -35,7 +35,13 @@ const (
 	AlgorithmES512 Algorithm = -36
 
 	// PureEdDSA by RFC 8152.
+	//
+	// Deprecated: use AlgorithmEdDSA instead, which has
+	// the same value but with a more accurate name.
 	AlgorithmEd25519 Algorithm = -8
+
+	// PureEdDSA by RFC 8152.
+	AlgorithmEdDSA Algorithm = -8
 
 	// An invalid/unrecognised algorithm.
 	AlgorithmInvalid Algorithm = 0
@@ -65,7 +71,7 @@ func (a Algorithm) String() string {
 		return "ES384"
 	case AlgorithmES512:
 		return "ES512"
-	case AlgorithmEd25519:
+	case AlgorithmEdDSA:
 		// As stated in RFC 8152 8.2, only the pure EdDSA version is used for
 		// COSE.
 		return "EdDSA"

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -96,7 +96,7 @@ func TestAlgorithm_computeHash(t *testing.T) {
 		},
 		{
 			name:    "Ed25519",
-			alg:     AlgorithmEd25519,
+			alg:     AlgorithmEdDSA,
 			wantErr: ErrUnavailableHashFunc,
 		},
 		{

--- a/ed25519.go
+++ b/ed25519.go
@@ -13,7 +13,7 @@ type ed25519Signer struct {
 
 // Algorithm returns the signing algorithm associated with the private key.
 func (es *ed25519Signer) Algorithm() Algorithm {
-	return AlgorithmEd25519
+	return AlgorithmEdDSA
 }
 
 // Sign signs message content with the private key, possibly using entropy from
@@ -34,7 +34,7 @@ type ed25519Verifier struct {
 
 // Algorithm returns the signing algorithm associated with the public key.
 func (ev *ed25519Verifier) Algorithm() Algorithm {
-	return AlgorithmEd25519
+	return AlgorithmEdDSA
 }
 
 // Verify verifies message content with the public key, returning nil for

--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -17,7 +17,7 @@ func generateTestEd25519Key(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey
 
 func Test_ed25519Signer(t *testing.T) {
 	// generate key
-	alg := AlgorithmEd25519
+	alg := AlgorithmEdDSA
 	_, key := generateTestEd25519Key(t)
 
 	// set up signer
@@ -51,7 +51,7 @@ func Test_ed25519Signer(t *testing.T) {
 
 func Test_ed25519Verifier_Verify_Success(t *testing.T) {
 	// generate key
-	alg := AlgorithmEd25519
+	alg := AlgorithmEdDSA
 	_, key := generateTestEd25519Key(t)
 
 	// generate a valid signature
@@ -77,7 +77,7 @@ func Test_ed25519Verifier_Verify_Success(t *testing.T) {
 
 func Test_ed25519Verifier_Verify_KeyMismatch(t *testing.T) {
 	// generate key
-	alg := AlgorithmEd25519
+	alg := AlgorithmEdDSA
 	_, key := generateTestEd25519Key(t)
 
 	// generate a valid signature
@@ -97,7 +97,7 @@ func Test_ed25519Verifier_Verify_KeyMismatch(t *testing.T) {
 
 func Test_ed25519Verifier_Verify_InvalidSignature(t *testing.T) {
 	// generate key
-	alg := AlgorithmEd25519
+	alg := AlgorithmEdDSA
 	vk, sk := generateTestEd25519Key(t)
 
 	// generate a valid signature with a tampered one

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -24,7 +24,7 @@ import (
 var supportedAlgorithms = [...]cose.Algorithm{
 	cose.AlgorithmPS256, cose.AlgorithmPS384, cose.AlgorithmPS512,
 	cose.AlgorithmES256, cose.AlgorithmES384, cose.AlgorithmES512,
-	cose.AlgorithmEd25519,
+	cose.AlgorithmEdDSA,
 }
 
 func FuzzSign1Message_UnmarshalCBOR(f *testing.F) {
@@ -181,7 +181,7 @@ func newSignerWithEphemeralKey(alg cose.Algorithm) (sv signVerifier, err error) 
 		key, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	case cose.AlgorithmES512:
 		key, err = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
-	case cose.AlgorithmEd25519:
+	case cose.AlgorithmEdDSA:
 		_, key, err = ed25519.GenerateKey(rand.Reader)
 	default:
 		err = cose.ErrAlgorithmNotSupported

--- a/key.go
+++ b/key.go
@@ -240,7 +240,7 @@ type Key struct {
 
 // NewOKPKey returns a Key created using the provided Octet Key Pair data.
 func NewOKPKey(alg Algorithm, x, d []byte) (*Key, error) {
-	if alg != AlgorithmEd25519 {
+	if alg != AlgorithmEdDSA {
 		return nil, fmt.Errorf("unsupported algorithm %q", alg)
 	}
 
@@ -389,7 +389,7 @@ func NewKeyFromPublic(pub crypto.PublicKey) (*Key, error) {
 
 		return NewEC2Key(alg, vk.X.Bytes(), vk.Y.Bytes(), nil)
 	case ed25519.PublicKey:
-		return NewOKPKey(AlgorithmEd25519, []byte(vk), nil)
+		return NewOKPKey(AlgorithmEdDSA, []byte(vk), nil)
 	default:
 		return nil, ErrInvalidPubKey
 	}
@@ -408,7 +408,7 @@ func NewKeyFromPrivate(priv crypto.PrivateKey) (*Key, error) {
 
 		return NewEC2Key(alg, sk.X.Bytes(), sk.Y.Bytes(), sk.D.Bytes())
 	case ed25519.PrivateKey:
-		return NewOKPKey(AlgorithmEd25519, []byte(sk[32:]), []byte(sk[:32]))
+		return NewOKPKey(AlgorithmEdDSA, []byte(sk[32:]), []byte(sk[:32]))
 	default:
 		return nil, ErrInvalidPrivKey
 	}
@@ -679,7 +679,7 @@ func (k *Key) PublicKey() (crypto.PublicKey, error) {
 		pub.Y.SetBytes(y)
 
 		return pub, nil
-	case AlgorithmEd25519:
+	case AlgorithmEdDSA:
 		_, x, _ := k.OKP()
 		return ed25519.PublicKey(x), nil
 	default:
@@ -724,7 +724,7 @@ func (k *Key) PrivateKey() (crypto.PrivateKey, error) {
 			PublicKey: ecdsa.PublicKey{Curve: curve, X: bx, Y: by},
 			D:         bd,
 		}, nil
-	case AlgorithmEd25519:
+	case AlgorithmEdDSA:
 		_, x, d := k.OKP()
 		if len(x) == 0 {
 			return ed25519.NewKeyFromSeed(d), nil
@@ -817,7 +817,7 @@ func (k *Key) deriveAlgorithm() (Algorithm, error) {
 		crv, _, _ := k.OKP()
 		switch crv {
 		case CurveEd25519:
-			return AlgorithmEd25519, nil
+			return AlgorithmEdDSA, nil
 		default:
 			return AlgorithmInvalid, fmt.Errorf(
 				"unsupported curve %q for key type OKP", crv.String())

--- a/key_test.go
+++ b/key_test.go
@@ -457,7 +457,7 @@ func TestKey_UnmarshalCBOR(t *testing.T) {
 			},
 			want: &Key{
 				KeyType:   KeyTypeOKP,
-				Algorithm: AlgorithmEd25519,
+				Algorithm: AlgorithmEdDSA,
 				KeyOps:    []KeyOp{KeyOpVerify, KeyOpSign},
 				BaseIV:    []byte{0x03, 0x02, 0x01},
 				Params: map[interface{}]interface{}{
@@ -644,7 +644,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 			name: "OKP with kty and alg",
 			key: &Key{
 				KeyType:   KeyTypeOKP,
-				Algorithm: AlgorithmEd25519,
+				Algorithm: AlgorithmEdDSA,
 			},
 			want: []byte{
 				0xa2,       // map (2)
@@ -730,7 +730,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 			name: "OKP",
 			key: &Key{
 				KeyType:   KeyTypeOKP,
-				Algorithm: AlgorithmEd25519,
+				Algorithm: AlgorithmEdDSA,
 				KeyOps:    []KeyOp{KeyOpVerify, KeyOpEncrypt},
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
@@ -846,10 +846,10 @@ func TestNewOKPKey(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "valid", args: args{AlgorithmEd25519, x, d},
+			name: "valid", args: args{AlgorithmEdDSA, x, d},
 			want: &Key{
 				KeyType:   KeyTypeOKP,
-				Algorithm: AlgorithmEd25519,
+				Algorithm: AlgorithmEdDSA,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     x,
@@ -862,7 +862,7 @@ func TestNewOKPKey(t *testing.T) {
 			want:    nil,
 			wantErr: `unsupported algorithm "unknown algorithm value -100"`,
 		}, {
-			name: "x and d missing", args: args{AlgorithmEd25519, nil, nil},
+			name: "x and d missing", args: args{AlgorithmEdDSA, nil, nil},
 			want:    nil,
 			wantErr: "invalid key: required parameters missing",
 		},
@@ -1061,7 +1061,7 @@ func TestKey_AlgorithmOrDefault(t *testing.T) {
 					KeyLabelOKPCurve: CurveEd25519,
 				},
 			},
-			AlgorithmEd25519,
+			AlgorithmEdDSA,
 			"",
 		},
 		{
@@ -1170,7 +1170,7 @@ func TestNewKeyFromPrivate(t *testing.T) {
 		{
 			"ed25519", ed25519.PrivateKey(append(okpd, okpx...)),
 			&Key{
-				Algorithm: AlgorithmEd25519, KeyType: KeyTypeOKP,
+				Algorithm: AlgorithmEdDSA, KeyType: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     okpx,
@@ -1228,7 +1228,7 @@ func TestNewKeyFromPublic(t *testing.T) {
 		{
 			"ed25519", ed25519.PublicKey(okpx),
 			&Key{
-				Algorithm: AlgorithmEd25519,
+				Algorithm: AlgorithmEdDSA,
 				KeyType:   KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
@@ -1275,20 +1275,20 @@ func TestKey_Signer(t *testing.T) {
 					KeyLabelOKPD:     d,
 				},
 			},
-			AlgorithmEd25519,
+			AlgorithmEdDSA,
 			"",
 		},
 		{
 			"without key_ops", &Key{
 				KeyType:   KeyTypeOKP,
-				Algorithm: AlgorithmEd25519,
+				Algorithm: AlgorithmEdDSA,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     x,
 					KeyLabelOKPD:     d,
 				},
 			},
-			AlgorithmEd25519,
+			AlgorithmEdDSA,
 			"",
 		},
 		{
@@ -1361,19 +1361,19 @@ func TestKey_Verifier(t *testing.T) {
 					KeyLabelOKPX:     x,
 				},
 			},
-			AlgorithmEd25519,
+			AlgorithmEdDSA,
 			"",
 		},
 		{
 			"without key_ops", &Key{
 				KeyType:   KeyTypeOKP,
-				Algorithm: AlgorithmEd25519,
+				Algorithm: AlgorithmEdDSA,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     x,
 				},
 			},
-			AlgorithmEd25519,
+			AlgorithmEdDSA,
 			"",
 		},
 		{

--- a/signer.go
+++ b/signer.go
@@ -68,7 +68,7 @@ func NewSigner(alg Algorithm, key crypto.Signer) (Signer, error) {
 			key:    vk,
 			signer: key,
 		}, nil
-	case AlgorithmEd25519:
+	case AlgorithmEdDSA:
 		if _, ok := key.Public().(ed25519.PublicKey); !ok {
 			return nil, fmt.Errorf("%v: %w", alg, ErrInvalidPubKey)
 		}

--- a/signer_test.go
+++ b/signer_test.go
@@ -77,7 +77,7 @@ func TestNewSigner(t *testing.T) {
 		},
 		{
 			name: "ed25519 signer",
-			alg:  AlgorithmEd25519,
+			alg:  AlgorithmEdDSA,
 			key:  ed25519Key,
 			want: &ed25519Signer{
 				key: ed25519Key,
@@ -85,7 +85,7 @@ func TestNewSigner(t *testing.T) {
 		},
 		{
 			name:    "ed25519 key mismatch",
-			alg:     AlgorithmEd25519,
+			alg:     AlgorithmEdDSA,
 			key:     rsaKey,
 			wantErr: "EdDSA: invalid public key",
 		},

--- a/verifier.go
+++ b/verifier.go
@@ -53,7 +53,7 @@ func NewVerifier(alg Algorithm, key crypto.PublicKey) (Verifier, error) {
 			alg: alg,
 			key: vk,
 		}, nil
-	case AlgorithmEd25519:
+	case AlgorithmEdDSA:
 		vk, ok := key.(ed25519.PublicKey)
 		if !ok {
 			return nil, fmt.Errorf("%v: %w", alg, ErrInvalidPubKey)

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -73,7 +73,7 @@ func TestNewVerifier(t *testing.T) {
 		},
 		{
 			name: "ed25519 verifier",
-			alg:  AlgorithmEd25519,
+			alg:  AlgorithmEdDSA,
 			key:  ed25519Key,
 			want: &ed25519Verifier{
 				key: ed25519Key,
@@ -81,7 +81,7 @@ func TestNewVerifier(t *testing.T) {
 		},
 		{
 			name:    "ed25519 invalid public key",
-			alg:     AlgorithmEd25519,
+			alg:     AlgorithmEdDSA,
 			key:     rsaKey,
 			wantErr: "EdDSA: invalid public key",
 		},


### PR DESCRIPTION
[RFC 88152 Section 8.2](https://www.rfc-editor.org/rfc/rfc8152#section-8.2) names the Edwards-Curve Digital Signature algorithm as `EdDSA`, but `go-cose` defines it as `const AlgorithmEd25519 = -8`. Our naming is misleading, the `-8` value can be used with other curves as well, e.g., `Ed448`, and the concept of an Ed25519 algorithm does not appear in the spec. We are mixing algorithms with curves.

We can't just rename the algorithm constant, it would break the API, but we can deprecate it and create a new one with a more accurate name: `AlgorithmEdDSA`,