### PR TITLE
Consolidate API names related to Key

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -43,8 +43,8 @@ const (
 	// PureEdDSA by RFC 8152.
 	AlgorithmEdDSA Algorithm = -8
 
-	// An invalid/unrecognised algorithm.
-	AlgorithmInvalid Algorithm = 0
+	// Reserved value.
+	AlgorithmReserved Algorithm = 0
 )
 
 // Algorithm represents an IANA algorithm entry in the COSE Algorithms registry.
@@ -75,6 +75,8 @@ func (a Algorithm) String() string {
 		// As stated in RFC 8152 8.2, only the pure EdDSA version is used for
 		// COSE.
 		return "EdDSA"
+	case AlgorithmReserved:
+		return "Reserved"
 	default:
 		return "unknown algorithm value " + strconv.Itoa(int(a))
 	}

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -12,18 +12,21 @@ import (
 func TestAlgorithm_String(t *testing.T) {
 	// run tests
 	tests := []struct {
-		name string
 		alg  Algorithm
 		want string
 	}{
-		{
-			name: "unknown algorithm",
-			alg:  0,
-			want: "unknown algorithm value 0",
-		},
+		{AlgorithmPS256, "PS256"},
+		{AlgorithmPS384, "PS384"},
+		{AlgorithmPS512, "PS512"},
+		{AlgorithmES256, "ES256"},
+		{AlgorithmES384, "ES384"},
+		{AlgorithmES512, "ES512"},
+		{AlgorithmEdDSA, "EdDSA"},
+		{AlgorithmReserved, "Reserved"},
+		{7, "unknown algorithm value 7"},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.want, func(t *testing.T) {
 			if got := tt.alg.String(); got != tt.want {
 				t.Errorf("Algorithm.String() = %v, want %v", got, tt.want)
 			}

--- a/headers.go
+++ b/headers.go
@@ -119,9 +119,9 @@ func (h ProtectedHeader) Algorithm() (Algorithm, error) {
 	case int64:
 		return Algorithm(alg), nil
 	case string:
-		return AlgorithmInvalid, fmt.Errorf("unknown algorithm value %q", alg)
+		return AlgorithmReserved, fmt.Errorf("unknown algorithm value %q", alg)
 	default:
-		return AlgorithmInvalid, ErrInvalidAlgorithm
+		return AlgorithmReserved, ErrInvalidAlgorithm
 	}
 }
 

--- a/key.go
+++ b/key.go
@@ -160,9 +160,14 @@ func (kt KeyType) String() string {
 	}
 }
 
+// Curve represents the EC2/OKP key's curve.
+//
+// https://datatracker.ietf.org/doc/html/rfc8152#section-13.1
+type Curve int64
+
 const (
-	// Invalid/unrecognised curve
-	CurveInvalid Curve = 0
+	// Reserved value
+	CurveReserved Curve = 0
 
 	// NIST P-256 also known as secp256r1
 	CurveP256 Curve = 1
@@ -186,10 +191,6 @@ const (
 	CurveEd448 Curve = 7
 )
 
-// Curve represents the EC2/OKP key's curve. See:
-// https://datatracker.ietf.org/doc/html/rfc8152#section-13.1
-type Curve int64
-
 // String returns a string representation of the Curve. Note does not
 // represent a valid value  of the corresponding serialized entry, and must
 // not be used as such.
@@ -209,6 +210,8 @@ func (c Curve) String() string {
 		return "Ed25519"
 	case CurveEd448:
 		return "Ed448"
+	case CurveReserved:
+		return "Reserved"
 	default:
 		return "unknown curve value " + strconv.Itoa(int(c))
 	}
@@ -437,7 +440,7 @@ func (k Key) validate(op KeyOp) error {
 				return ErrNotPrivKey
 			}
 		}
-		if crv == CurveInvalid || (len(x) == 0 && len(y) == 0 && len(d) == 0) {
+		if crv == CurveReserved || (len(x) == 0 && len(y) == 0 && len(d) == 0) {
 			return errReqParamsMissing
 		}
 		if size := curveSize(crv); size > 0 {
@@ -468,7 +471,7 @@ func (k Key) validate(op KeyOp) error {
 				return ErrNotPrivKey
 			}
 		}
-		if crv == CurveInvalid || (len(x) == 0 && len(d) == 0) {
+		if crv == CurveReserved || (len(x) == 0 && len(d) == 0) {
 			return errReqParamsMissing
 		}
 		if (len(x) > 0 && len(x) != ed25519.PublicKeySize) || (len(d) > 0 && len(d) != ed25519.SeedSize) {

--- a/key.go
+++ b/key.go
@@ -387,7 +387,7 @@ func NewKeyFromPublic(pub crypto.PublicKey) (*Key, error) {
 	case *ecdsa.PublicKey:
 		alg := algorithmFromEllipticCurve(vk.Curve)
 
-		if alg == AlgorithmInvalid {
+		if alg == AlgorithmReserved {
 			return nil, fmt.Errorf("unsupported curve: %v", vk.Curve)
 		}
 
@@ -406,7 +406,7 @@ func NewKeyFromPrivate(priv crypto.PrivateKey) (*Key, error) {
 	case *ecdsa.PrivateKey:
 		alg := algorithmFromEllipticCurve(sk.Curve)
 
-		if alg == AlgorithmInvalid {
+		if alg == AlgorithmReserved {
 			return nil, fmt.Errorf("unsupported curve: %v", sk.Curve)
 		}
 
@@ -500,7 +500,7 @@ func (k Key) validate(op KeyOp) error {
 	}
 
 	// If Algorithm is set, it must match the specified key parameters.
-	if k.Algorithm != AlgorithmInvalid {
+	if k.Algorithm != AlgorithmReserved {
 		expectedAlg, err := k.deriveAlgorithm()
 		if err != nil {
 			return err
@@ -538,7 +538,7 @@ func (k *Key) MarshalCBOR() ([]byte, error) {
 	if k.ID != nil {
 		tmp[keyLabelKeyID] = k.ID
 	}
-	if k.Algorithm != AlgorithmInvalid {
+	if k.Algorithm != AlgorithmReserved {
 		tmp[keyLabelAlgorithm] = k.Algorithm
 	}
 	if k.Ops != nil {
@@ -750,7 +750,7 @@ func (k *Key) PrivateKey() (crypto.PrivateKey, error) {
 // Key.Curve. This method does NOT validate that Key.Algorithm, if set, aligns
 // with Key.Curve.
 func (k *Key) AlgorithmOrDefault() (Algorithm, error) {
-	if k.Algorithm != AlgorithmInvalid {
+	if k.Algorithm != AlgorithmReserved {
 		return k.Algorithm, nil
 	}
 
@@ -814,7 +814,7 @@ func (k *Key) deriveAlgorithm() (Algorithm, error) {
 		case CurveP521:
 			return AlgorithmES512, nil
 		default:
-			return AlgorithmInvalid, fmt.Errorf(
+			return AlgorithmReserved, fmt.Errorf(
 				"unsupported curve %q for key type EC2", crv.String())
 		}
 	case KeyTypeOKP:
@@ -823,12 +823,12 @@ func (k *Key) deriveAlgorithm() (Algorithm, error) {
 		case CurveEd25519:
 			return AlgorithmEdDSA, nil
 		default:
-			return AlgorithmInvalid, fmt.Errorf(
+			return AlgorithmReserved, fmt.Errorf(
 				"unsupported curve %q for key type OKP", crv.String())
 		}
 	default:
 		// Symmetric algorithms are not supported in the current inmplementation.
-		return AlgorithmInvalid, fmt.Errorf("unexpected key type %q", k.Type.String())
+		return AlgorithmReserved, fmt.Errorf("unexpected key type %q", k.Type.String())
 	}
 }
 
@@ -841,7 +841,7 @@ func algorithmFromEllipticCurve(c elliptic.Curve) Algorithm {
 	case elliptic.P521():
 		return AlgorithmES512
 	default:
-		return AlgorithmInvalid
+		return AlgorithmReserved
 	}
 }
 

--- a/key.go
+++ b/key.go
@@ -238,8 +238,8 @@ type Key struct {
 	Params map[interface{}]interface{}
 }
 
-// NewOKPKey returns a Key created using the provided Octet Key Pair data.
-func NewOKPKey(alg Algorithm, x, d []byte) (*Key, error) {
+// NewKeyOKP returns a Key created using the provided Octet Key Pair data.
+func NewKeyOKP(alg Algorithm, x, d []byte) (*Key, error) {
 	if alg != AlgorithmEdDSA {
 		return nil, fmt.Errorf("unsupported algorithm %q", alg)
 	}
@@ -309,9 +309,9 @@ func (k *Key) OKP() (crv Curve, x []byte, d []byte) {
 	return
 }
 
-// NewEC2Key returns a Key created using the provided elliptic curve key
+// NewKeyEC2 returns a Key created using the provided elliptic curve key
 // data.
-func NewEC2Key(alg Algorithm, x, y, d []byte) (*Key, error) {
+func NewKeyEC2(alg Algorithm, x, y, d []byte) (*Key, error) {
 	var curve Curve
 
 	switch alg {
@@ -359,9 +359,9 @@ func (k *Key) EC2() (crv Curve, x []byte, y, d []byte) {
 	return
 }
 
-// NewSymmetricKey returns a Key created using the provided Symmetric key
+// NewKeySymmetric returns a Key created using the provided Symmetric key
 // bytes.
-func NewSymmetricKey(k []byte) *Key {
+func NewKeySymmetric(k []byte) *Key {
 	return &Key{
 		KeyType: KeyTypeSymmetric,
 		Params: map[interface{}]interface{}{
@@ -387,9 +387,9 @@ func NewKeyFromPublic(pub crypto.PublicKey) (*Key, error) {
 			return nil, fmt.Errorf("unsupported curve: %v", vk.Curve)
 		}
 
-		return NewEC2Key(alg, vk.X.Bytes(), vk.Y.Bytes(), nil)
+		return NewKeyEC2(alg, vk.X.Bytes(), vk.Y.Bytes(), nil)
 	case ed25519.PublicKey:
-		return NewOKPKey(AlgorithmEdDSA, []byte(vk), nil)
+		return NewKeyOKP(AlgorithmEdDSA, []byte(vk), nil)
 	default:
 		return nil, ErrInvalidPubKey
 	}
@@ -406,9 +406,9 @@ func NewKeyFromPrivate(priv crypto.PrivateKey) (*Key, error) {
 			return nil, fmt.Errorf("unsupported curve: %v", sk.Curve)
 		}
 
-		return NewEC2Key(alg, sk.X.Bytes(), sk.Y.Bytes(), sk.D.Bytes())
+		return NewKeyEC2(alg, sk.X.Bytes(), sk.Y.Bytes(), sk.D.Bytes())
 	case ed25519.PrivateKey:
-		return NewOKPKey(AlgorithmEdDSA, []byte(sk[32:]), []byte(sk[:32]))
+		return NewKeyOKP(AlgorithmEdDSA, []byte(sk[32:]), []byte(sk[:32]))
 	default:
 		return nil, ErrInvalidPrivKey
 	}

--- a/key.go
+++ b/key.go
@@ -34,7 +34,7 @@ const (
 )
 
 const (
-	// An inviald key_op value
+	// An invalid key_op value
 	KeyOpInvalid KeyOp = 0
 
 	// The key is used to create signatures. Requires private key fields.
@@ -131,18 +131,14 @@ func (ko KeyOp) String() string {
 }
 
 // KeyType identifies the family of keys represented by the associated Key.
-// This determines which files within the Key must be set in order for it to be
-// valid.
+//
+// https://datatracker.ietf.org/doc/html/rfc8152#section-13
 type KeyType int64
 
 const (
-	// Invlaid key type
-	KeyTypeInvalid KeyType = 0
-	// Octet Key Pair
-	KeyTypeOKP KeyType = 1
-	// Elliptic Curve Keys w/ x- and y-coordinate pair
-	KeyTypeEC2 KeyType = 2
-	// Symmetric Keys
+	KeyTypeReserved  KeyType = 0
+	KeyTypeOKP       KeyType = 1
+	KeyTypeEC2       KeyType = 2
 	KeyTypeSymmetric KeyType = 4
 )
 
@@ -157,13 +153,14 @@ func (kt KeyType) String() string {
 		return "EC2"
 	case KeyTypeSymmetric:
 		return "Symmetric"
+	case KeyTypeReserved:
+		return "Reserved"
 	default:
 		return "unknown key type value " + strconv.Itoa(int(kt))
 	}
 }
 
 const (
-
 	// Invalid/unrecognised curve
 	CurveInvalid Curve = 0
 
@@ -489,7 +486,7 @@ func (k Key) validate(op KeyOp) error {
 		if len(k) == 0 {
 			return errReqParamsMissing
 		}
-	case KeyTypeInvalid:
+	case KeyTypeReserved:
 		return fmt.Errorf("%w: kty value 0", ErrInvalidKey)
 	default:
 		// Unknown key type, we can't validate custom parameters.
@@ -586,7 +583,7 @@ func (k *Key) UnmarshalCBOR(data []byte) error {
 		return fmt.Errorf("kty: %w", err)
 	}
 	k.Type = KeyType(kty)
-	if k.Type == KeyTypeInvalid {
+	if k.Type == KeyTypeReserved {
 		return errors.New("kty: invalid value 0")
 	}
 	k.ID, _, err = decodeBytes(tmp, keyLabelKeyID)

--- a/key.go
+++ b/key.go
@@ -33,9 +33,15 @@ const (
 	keyLabelBaseIV    int64 = 5
 )
 
+// KeyOp represents a key_ops value used to restrict purposes for which a Key
+// may be used.
+//
+// https://datatracker.ietf.org/doc/html/rfc8152#section-7.1
+type KeyOp int64
+
 const (
-	// An invalid key_op value
-	KeyOpInvalid KeyOp = 0
+	// Reserved value.
+	KeyOpReserved KeyOp = 0
 
 	// The key is used to create signatures. Requires private key fields.
 	KeyOpSign KeyOp = 1
@@ -69,10 +75,6 @@ const (
 	KeyOpMACVerify KeyOp = 10
 )
 
-// KeyOp represents a key_ops value used to restrict purposes for which a Key
-// may be used.
-type KeyOp int64
-
 // KeyOpFromString returns the KeyOp corresponding to the specified name.
 // The values are taken from https://www.rfc-editor.org/rfc/rfc7517#section-4.3
 func KeyOpFromString(val string) (KeyOp, bool) {
@@ -94,7 +96,7 @@ func KeyOpFromString(val string) (KeyOp, bool) {
 	case "deriveBits":
 		return KeyOpDeriveBits, true
 	default:
-		return KeyOpInvalid, false
+		return KeyOpReserved, false
 	}
 }
 
@@ -125,6 +127,8 @@ func (ko KeyOp) String() string {
 		return "MAC create"
 	case KeyOpMACVerify:
 		return "MAC verify"
+	case KeyOpReserved:
+		return "Reserved"
 	default:
 		return "unknown key_op value " + strconv.Itoa(int(ko))
 	}
@@ -257,7 +261,7 @@ func NewKeyOKP(alg Algorithm, x, d []byte) (*Key, error) {
 	if d != nil {
 		key.Params[KeyLabelOKPD] = d
 	}
-	if err := key.validate(KeyOpInvalid); err != nil {
+	if err := key.validate(KeyOpReserved); err != nil {
 		return nil, err
 	}
 	return key, nil
@@ -341,7 +345,7 @@ func NewKeyEC2(alg Algorithm, x, y, d []byte) (*Key, error) {
 	if d != nil {
 		key.Params[KeyLabelEC2D] = d
 	}
-	if err := key.validate(KeyOpInvalid); err != nil {
+	if err := key.validate(KeyOpReserved); err != nil {
 		return nil, err
 	}
 	return key, nil
@@ -646,7 +650,7 @@ func (k *Key) UnmarshalCBOR(data []byte) error {
 			}
 		}
 	}
-	return k.validate(KeyOpInvalid)
+	return k.validate(KeyOpReserved)
 }
 
 // PublicKey returns a crypto.PublicKey generated using Key's parameters.

--- a/key_test.go
+++ b/key_test.go
@@ -202,6 +202,7 @@ func TestKeyOp_String(t *testing.T) {
 		op   KeyOp
 		want string
 	}{
+		{KeyOpReserved, "Reserved"},
 		{KeyOpSign, "sign"},
 		{KeyOpVerify, "verify"},
 		{KeyOpEncrypt, "encrypt"},

--- a/key_test.go
+++ b/key_test.go
@@ -832,7 +832,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 	}
 }
 
-func TestNewOKPKey(t *testing.T) {
+func TestNewKeyOKP(t *testing.T) {
 	x, d := newEd25519(t)
 	type args struct {
 		alg Algorithm
@@ -869,19 +869,19 @@ func TestNewOKPKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewOKPKey(tt.args.alg, tt.args.x, tt.args.d)
+			got, err := NewKeyOKP(tt.args.alg, tt.args.x, tt.args.d)
 			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
-				t.Errorf("NewOKPKey() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("NewKeyOKP() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewOKPKey() = %v, want %v", got, tt.want)
+				t.Errorf("NewKeyOKP() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestNewEC2Key(t *testing.T) {
+func TestNewNewKeyEC2(t *testing.T) {
 	ec256x, ec256y, ec256d := newEC2(t, elliptic.P256())
 	ec384x, ec384y, ec384d := newEC2(t, elliptic.P384())
 	ec521x, ec521y, ec521d := newEC2(t, elliptic.P521())
@@ -948,19 +948,19 @@ func TestNewEC2Key(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewEC2Key(tt.args.alg, tt.args.x, tt.args.y, tt.args.d)
+			got, err := NewKeyEC2(tt.args.alg, tt.args.x, tt.args.y, tt.args.d)
 			if (err != nil && err.Error() != tt.wantErr) || (err == nil && tt.wantErr != "") {
-				t.Errorf("NewEC2Key() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("NewKeyEC2() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewEC2Key() = %v, want %v", got, tt.want)
+				t.Errorf("NewKeyEC2() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestNewSymmetricKey(t *testing.T) {
+func TestNewKeySymmetric(t *testing.T) {
 	type args struct {
 		k []byte
 	}
@@ -978,8 +978,8 @@ func TestNewSymmetricKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewSymmetricKey(tt.args.k); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewSymmetricKey() = %v, want %v", got, tt.want)
+			if got := NewKeySymmetric(tt.args.k); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewKeySymmetric() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/key_test.go
+++ b/key_test.go
@@ -1073,7 +1073,7 @@ func TestKey_AlgorithmOrDefault(t *testing.T) {
 					KeyLabelOKPCurve: CurveP256,
 				},
 			},
-			AlgorithmInvalid,
+			AlgorithmReserved,
 			`unsupported curve "P-256" for key type OKP`,
 		},
 		{
@@ -1117,7 +1117,7 @@ func TestKey_AlgorithmOrDefault(t *testing.T) {
 					KeyLabelEC2Curve: CurveEd25519,
 				},
 			},
-			AlgorithmInvalid,
+			AlgorithmReserved,
 			`unsupported curve "Ed25519" for key type EC2`,
 		},
 	}
@@ -1301,7 +1301,7 @@ func TestKey_Signer(t *testing.T) {
 					KeyLabelOKPD:     d,
 				},
 			},
-			AlgorithmInvalid,
+			AlgorithmReserved,
 			"invalid key: curve not supported for the given key type",
 		},
 		{
@@ -1314,7 +1314,7 @@ func TestKey_Signer(t *testing.T) {
 					KeyLabelOKPD:     d,
 				},
 			},
-			AlgorithmInvalid,
+			AlgorithmReserved,
 			ErrOpNotSupported.Error(),
 		},
 		{
@@ -1325,7 +1325,7 @@ func TestKey_Signer(t *testing.T) {
 					KeyLabelSymmetricK: d,
 				},
 			},
-			AlgorithmInvalid,
+			AlgorithmReserved,
 			`unexpected key type "Symmetric"`,
 		},
 	}
@@ -1385,7 +1385,7 @@ func TestKey_Verifier(t *testing.T) {
 					KeyLabelOKPX:     x,
 				},
 			},
-			AlgorithmInvalid,
+			AlgorithmReserved,
 			"invalid key: curve not supported for the given key type",
 		},
 		{
@@ -1397,7 +1397,7 @@ func TestKey_Verifier(t *testing.T) {
 					KeyLabelOKPX:     x,
 				},
 			},
-			AlgorithmInvalid,
+			AlgorithmReserved,
 			ErrOpNotSupported.Error(),
 		},
 		{
@@ -1408,7 +1408,7 @@ func TestKey_Verifier(t *testing.T) {
 					KeyLabelSymmetricK: x,
 				},
 			},
-			AlgorithmInvalid,
+			AlgorithmReserved,
 			`unexpected key type "Symmetric"`,
 		},
 	}

--- a/key_test.go
+++ b/key_test.go
@@ -431,7 +431,7 @@ func TestKey_UnmarshalCBOR(t *testing.T) {
 				0x61, 0x66, 0x63, 0x66, 0x6f, 0x6f, // 0x21: foo
 			},
 			want: &Key{
-				KeyType: -70000,
+				Type: -70000,
 				Params: map[interface{}]interface{}{
 					int64(-1): int64(6),
 					"f":       "foo",
@@ -456,9 +456,9 @@ func TestKey_UnmarshalCBOR(t *testing.T) {
 				0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
 			},
 			want: &Key{
-				KeyType:   KeyTypeOKP,
+				Type:      KeyTypeOKP,
 				Algorithm: AlgorithmEdDSA,
-				KeyOps:    []KeyOp{KeyOpVerify, KeyOpSign},
+				Ops:       []KeyOp{KeyOpVerify, KeyOpSign},
 				BaseIV:    []byte{0x03, 0x02, 0x01},
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
@@ -483,7 +483,7 @@ func TestKey_UnmarshalCBOR(t *testing.T) {
 				0x28, 0x14, 0x87, 0xef, 0x4a, 0xe6, 0x7b, 0x46,
 			},
 			want: &Key{
-				KeyType: KeyTypeSymmetric,
+				Type: KeyTypeSymmetric,
 				Params: map[interface{}]interface{}{
 					KeyLabelSymmetricK: []byte{
 						0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3,
@@ -505,8 +505,8 @@ func TestKey_UnmarshalCBOR(t *testing.T) {
 				"21582065eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d" +
 				"2258201e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c"),
 			want: &Key{
-				KeyType: KeyTypeEC2,
-				KeyID:   []byte("meriadoc.brandybuck@buckland.example"),
+				Type: KeyTypeEC2,
+				ID:   []byte("meriadoc.brandybuck@buckland.example"),
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2X:     mustHexToBytes("65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d"),
@@ -523,8 +523,8 @@ func TestKey_UnmarshalCBOR(t *testing.T) {
 				"2158420072992cb3ac08ecf3e5c63dedec0d51a8c1f79ef2f82f94f3c737bf5de7986671eac625fe8257bbd0394644caaa3aaf8f27a4585fbbcad0f2457620085e5c8f42ad" +
 				"22584201dca6947bce88bc5790485ac97427342bc35f887d86d65a089377e247e60baa55e4e8501e2ada5724ac51d6909008033ebc10ac999b9d7f5cc2519f3fe1ea1d9475"),
 			want: &Key{
-				KeyType: KeyTypeEC2,
-				KeyID:   []byte("bilbo.baggins@hobbiton.example"),
+				Type: KeyTypeEC2,
+				ID:   []byte("bilbo.baggins@hobbiton.example"),
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP521,
 					KeyLabelEC2X:     mustHexToBytes("0072992cb3ac08ecf3e5c63dedec0d51a8c1f79ef2f82f94f3c737bf5de7986671eac625fe8257bbd0394644caaa3aaf8f27a4585fbbcad0f2457620085e5c8f42ad"),
@@ -543,8 +543,8 @@ func TestKey_UnmarshalCBOR(t *testing.T) {
 				"2258201e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c" +
 				"235820aff907c99f9ad3aae6c4cdf21122bce2bd68b5283e6907154ad911840fa208cf"),
 			want: &Key{
-				KeyType: KeyTypeEC2,
-				KeyID:   []byte("meriadoc.brandybuck@buckland.example"),
+				Type: KeyTypeEC2,
+				ID:   []byte("meriadoc.brandybuck@buckland.example"),
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2X:     mustHexToBytes("65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d"),
@@ -562,8 +562,8 @@ func TestKey_UnmarshalCBOR(t *testing.T) {
 				"22584201dca6947bce88bc5790485ac97427342bc35f887d86d65a089377e247e60baa55e4e8501e2ada5724ac51d6909008033ebc10ac999b9d7f5cc2519f3fe1ea1d9475" +
 				"23584200085138ddabf5ca975f5860f91a08e91d6d5f9a76ad4018766a476680b55cd339e8ab6c72b5facdb2a2a50ac25bd086647dd3e2e6e99e84ca2c3609fdf177feb26d"),
 			want: &Key{
-				KeyType: KeyTypeEC2,
-				KeyID:   []byte("bilbo.baggins@hobbiton.example"),
+				Type: KeyTypeEC2,
+				ID:   []byte("bilbo.baggins@hobbiton.example"),
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP521,
 					KeyLabelEC2X:     mustHexToBytes("0072992cb3ac08ecf3e5c63dedec0d51a8c1f79ef2f82f94f3c737bf5de7986671eac625fe8257bbd0394644caaa3aaf8f27a4585fbbcad0f2457620085e5c8f42ad"),
@@ -578,8 +578,8 @@ func TestKey_UnmarshalCBOR(t *testing.T) {
 				"024a6f75722d736563726574" +
 				"205820849b57219dae48de646d07dbb533566e976686457c1491be3a76dcea6c427188"),
 			want: &Key{
-				KeyType: KeyTypeSymmetric,
-				KeyID:   []byte("our-secret"),
+				Type: KeyTypeSymmetric,
+				ID:   []byte("our-secret"),
 				Params: map[interface{}]interface{}{
 					KeyLabelSymmetricK: mustHexToBytes("849b57219dae48de646d07dbb533566e976686457c1491be3a76dcea6c427188"),
 				},
@@ -612,8 +612,8 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		{
 			name: "OKP with kty and kid",
 			key: &Key{
-				KeyType: KeyTypeOKP,
-				KeyID:   []byte{1, 2, 3},
+				Type: KeyTypeOKP,
+				ID:   []byte{1, 2, 3},
 			},
 			want: []byte{
 				0xa2,       // map (2)
@@ -623,7 +623,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "OKP with only kty",
 			key: &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 			},
 			want: []byte{
 				0xa1,       // map (1)
@@ -632,8 +632,8 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "OKP with kty and base_iv",
 			key: &Key{
-				KeyType: KeyTypeOKP,
-				BaseIV:  []byte{3, 2, 1},
+				Type:   KeyTypeOKP,
+				BaseIV: []byte{3, 2, 1},
 			},
 			want: []byte{
 				0xa2,       // map (2)
@@ -643,7 +643,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "OKP with kty and alg",
 			key: &Key{
-				KeyType:   KeyTypeOKP,
+				Type:      KeyTypeOKP,
 				Algorithm: AlgorithmEdDSA,
 			},
 			want: []byte{
@@ -654,7 +654,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "OKP with kty and private alg",
 			key: &Key{
-				KeyType:   KeyTypeOKP,
+				Type:      KeyTypeOKP,
 				Algorithm: -70_000,
 			},
 			want: []byte{
@@ -665,9 +665,9 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "OKP with kty and key_ops",
 			key: &Key{
-				KeyType: KeyTypeOKP,
-				KeyID:   []byte{1, 2, 3},
-				KeyOps:  []KeyOp{KeyOpEncrypt, KeyOpDecrypt, -70_000},
+				Type: KeyTypeOKP,
+				ID:   []byte{1, 2, 3},
+				Ops:  []KeyOp{KeyOpEncrypt, KeyOpDecrypt, -70_000},
 			},
 			want: []byte{
 				0xa3,       // map (3)
@@ -679,7 +679,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "OKP with kty and private int params",
 			key: &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					0x46: 0x47,
 					0x66: 0x67,
@@ -694,7 +694,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "OKP with kty and private mixed params",
 			key: &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					0x1234: 0x47,
 					"a":    0x67,
@@ -709,7 +709,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "OKP duplicated params",
 			key: &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					int8(10):  0,
 					int32(10): 1,
@@ -719,7 +719,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "OKP with invalid param label",
 			key: &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					int8(10): 0,
 					-3.5:     1,
@@ -729,9 +729,9 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "OKP",
 			key: &Key{
-				KeyType:   KeyTypeOKP,
+				Type:      KeyTypeOKP,
 				Algorithm: AlgorithmEdDSA,
-				KeyOps:    []KeyOp{KeyOpVerify, KeyOpEncrypt},
+				Ops:       []KeyOp{KeyOpVerify, KeyOpEncrypt},
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX: []byte{
@@ -760,7 +760,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "EC2 with short x and y",
 			key: &Key{
-				KeyType:   KeyTypeEC2,
+				Type:      KeyTypeEC2,
 				Algorithm: AlgorithmES256,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
@@ -788,7 +788,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 		}, {
 			name: "Symmetric",
 			key: &Key{
-				KeyType: KeyTypeSymmetric,
+				Type: KeyTypeSymmetric,
 				Params: map[interface{}]interface{}{
 					KeyLabelSymmetricK: []byte{
 						0x15, 0x52, 0x2e, 0xf1, 0x57, 0x29, 0xcc, 0xf3,
@@ -810,7 +810,7 @@ func TestKey_MarshalCBOR(t *testing.T) {
 			wantErr: "",
 		}, {
 			name: "unknown key type",
-			key:  &Key{KeyType: 42},
+			key:  &Key{Type: 42},
 			want: []byte{
 				0xa1,             // map (1)
 				0x01, 0x18, 0x2a, // kty: 42
@@ -848,7 +848,7 @@ func TestNewKeyOKP(t *testing.T) {
 		{
 			name: "valid", args: args{AlgorithmEdDSA, x, d},
 			want: &Key{
-				KeyType:   KeyTypeOKP,
+				Type:      KeyTypeOKP,
 				Algorithm: AlgorithmEdDSA,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
@@ -900,7 +900,7 @@ func TestNewNewKeyEC2(t *testing.T) {
 		{
 			name: "valid ES256", args: args{AlgorithmES256, ec256x, ec256y, ec256d},
 			want: &Key{
-				KeyType:   KeyTypeEC2,
+				Type:      KeyTypeEC2,
 				Algorithm: AlgorithmES256,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
@@ -913,7 +913,7 @@ func TestNewNewKeyEC2(t *testing.T) {
 		}, {
 			name: "valid ES384", args: args{AlgorithmES384, ec384x, ec384y, ec384d},
 			want: &Key{
-				KeyType:   KeyTypeEC2,
+				Type:      KeyTypeEC2,
 				Algorithm: AlgorithmES384,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP384,
@@ -926,7 +926,7 @@ func TestNewNewKeyEC2(t *testing.T) {
 		}, {
 			name: "valid ES521", args: args{AlgorithmES512, ec521x, ec521y, ec521d},
 			want: &Key{
-				KeyType:   KeyTypeEC2,
+				Type:      KeyTypeEC2,
 				Algorithm: AlgorithmES512,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP521,
@@ -970,7 +970,7 @@ func TestNewKeySymmetric(t *testing.T) {
 		want *Key
 	}{
 		{"valid", args{[]byte{1, 2, 3}}, &Key{
-			KeyType: KeyTypeSymmetric,
+			Type: KeyTypeSymmetric,
 			Params: map[interface{}]interface{}{
 				KeyLabelSymmetricK: []byte{1, 2, 3},
 			},
@@ -1056,7 +1056,7 @@ func TestKey_AlgorithmOrDefault(t *testing.T) {
 		{
 			"OKP-Ed25519",
 			&Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 				},
@@ -1067,7 +1067,7 @@ func TestKey_AlgorithmOrDefault(t *testing.T) {
 		{
 			"OKP-P256",
 			&Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveP256,
 				},
@@ -1078,7 +1078,7 @@ func TestKey_AlgorithmOrDefault(t *testing.T) {
 		{
 			"EC2-P256",
 			&Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 				},
@@ -1089,7 +1089,7 @@ func TestKey_AlgorithmOrDefault(t *testing.T) {
 		{
 			"EC2-P384",
 			&Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP384,
 				},
@@ -1100,7 +1100,7 @@ func TestKey_AlgorithmOrDefault(t *testing.T) {
 		{
 			"EC2-P521",
 			&Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP521,
 				},
@@ -1111,7 +1111,7 @@ func TestKey_AlgorithmOrDefault(t *testing.T) {
 		{
 			"EC2-Ed25519",
 			&Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveEd25519,
 				},
@@ -1149,7 +1149,7 @@ func TestNewKeyFromPrivate(t *testing.T) {
 				D:         new(big.Int).SetBytes(d),
 			}, &Key{
 				Algorithm: AlgorithmES256,
-				KeyType:   KeyTypeEC2,
+				Type:      KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2X:     x,
@@ -1170,7 +1170,7 @@ func TestNewKeyFromPrivate(t *testing.T) {
 		{
 			"ed25519", ed25519.PrivateKey(append(okpd, okpx...)),
 			&Key{
-				Algorithm: AlgorithmEdDSA, KeyType: KeyTypeOKP,
+				Algorithm: AlgorithmEdDSA, Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     okpx,
@@ -1211,7 +1211,7 @@ func TestNewKeyFromPublic(t *testing.T) {
 			"ecdsa", &ecdsa.PublicKey{Curve: elliptic.P256(), X: new(big.Int).SetBytes(ecx), Y: new(big.Int).SetBytes(ecy)},
 			&Key{
 				Algorithm: AlgorithmES256,
-				KeyType:   KeyTypeEC2,
+				Type:      KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2X:     ecx,
@@ -1229,7 +1229,7 @@ func TestNewKeyFromPublic(t *testing.T) {
 			"ed25519", ed25519.PublicKey(okpx),
 			&Key{
 				Algorithm: AlgorithmEdDSA,
-				KeyType:   KeyTypeOKP,
+				Type:      KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     okpx,
@@ -1267,8 +1267,8 @@ func TestKey_Signer(t *testing.T) {
 	}{
 		{
 			"without algorithm", &Key{
-				KeyType: KeyTypeOKP,
-				KeyOps:  []KeyOp{KeyOpSign},
+				Type: KeyTypeOKP,
+				Ops:  []KeyOp{KeyOpSign},
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     x,
@@ -1280,7 +1280,7 @@ func TestKey_Signer(t *testing.T) {
 		},
 		{
 			"without key_ops", &Key{
-				KeyType:   KeyTypeOKP,
+				Type:      KeyTypeOKP,
 				Algorithm: AlgorithmEdDSA,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
@@ -1293,7 +1293,7 @@ func TestKey_Signer(t *testing.T) {
 		},
 		{
 			"invalid algorithm", &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveP256,
 					KeyLabelOKPX:     x,
@@ -1305,8 +1305,8 @@ func TestKey_Signer(t *testing.T) {
 		},
 		{
 			"can't sign", &Key{
-				KeyType: KeyTypeOKP,
-				KeyOps:  []KeyOp{KeyOpVerify},
+				Type: KeyTypeOKP,
+				Ops:  []KeyOp{KeyOpVerify},
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     x,
@@ -1318,8 +1318,8 @@ func TestKey_Signer(t *testing.T) {
 		},
 		{
 			"unsupported key", &Key{
-				KeyType: KeyTypeSymmetric,
-				KeyOps:  []KeyOp{KeyOpSign},
+				Type: KeyTypeSymmetric,
+				Ops:  []KeyOp{KeyOpSign},
 				Params: map[interface{}]interface{}{
 					KeyLabelSymmetricK: d,
 				},
@@ -1354,8 +1354,8 @@ func TestKey_Verifier(t *testing.T) {
 	}{
 		{
 			"without algorithm", &Key{
-				KeyType: KeyTypeOKP,
-				KeyOps:  []KeyOp{KeyOpVerify},
+				Type: KeyTypeOKP,
+				Ops:  []KeyOp{KeyOpVerify},
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     x,
@@ -1366,7 +1366,7 @@ func TestKey_Verifier(t *testing.T) {
 		},
 		{
 			"without key_ops", &Key{
-				KeyType:   KeyTypeOKP,
+				Type:      KeyTypeOKP,
 				Algorithm: AlgorithmEdDSA,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
@@ -1378,7 +1378,7 @@ func TestKey_Verifier(t *testing.T) {
 		},
 		{
 			"invalid algorithm", &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveP256,
 					KeyLabelOKPX:     x,
@@ -1389,8 +1389,8 @@ func TestKey_Verifier(t *testing.T) {
 		},
 		{
 			"can't verify", &Key{
-				KeyType: KeyTypeOKP,
-				KeyOps:  []KeyOp{KeyOpSign},
+				Type: KeyTypeOKP,
+				Ops:  []KeyOp{KeyOpSign},
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     x,
@@ -1401,8 +1401,8 @@ func TestKey_Verifier(t *testing.T) {
 		},
 		{
 			"unsupported key", &Key{
-				KeyType: KeyTypeSymmetric,
-				KeyOps:  []KeyOp{KeyOpVerify},
+				Type: KeyTypeSymmetric,
+				Ops:  []KeyOp{KeyOpVerify},
 				Params: map[interface{}]interface{}{
 					KeyLabelSymmetricK: x,
 				},
@@ -1440,7 +1440,7 @@ func TestKey_PrivateKey(t *testing.T) {
 	}{
 		{
 			"CurveEd25519", &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     okpx,
@@ -1451,7 +1451,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			"",
 		}, {
 			"CurveEd25519 missing x", &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPD:     okpd,
@@ -1461,7 +1461,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			"",
 		}, {
 			"CurveP256", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2X:     ec256x,
@@ -1480,7 +1480,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			"",
 		}, {
 			"CurveP256 missing x and y", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2D:     ec256d,
@@ -1497,7 +1497,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			"",
 		}, {
 			"CurveP384", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP384,
 					KeyLabelEC2X:     ec384x,
@@ -1516,7 +1516,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			"",
 		}, {
 			"CurveP521", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP521,
 					KeyLabelEC2X:     ec521x,
@@ -1535,13 +1535,13 @@ func TestKey_PrivateKey(t *testing.T) {
 			"",
 		}, {
 			"unknown key type", &Key{
-				KeyType: KeyType(7),
+				Type: KeyType(7),
 			},
 			nil,
 			`unexpected key type "unknown key type value 7"`,
 		}, {
 			"OKP unknown curve", &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: 70,
 					KeyLabelOKPX:     okpx,
@@ -1552,7 +1552,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			`unsupported curve "unknown curve value 70" for key type OKP`,
 		}, {
 			"OKP missing d", &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     okpx,
@@ -1562,7 +1562,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			ErrNotPrivKey.Error(),
 		}, {
 			"OKP incorrect x size", &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     make([]byte, 10),
@@ -1573,7 +1573,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			"invalid key: overflowing coordinate",
 		}, {
 			"OKP incorrect d size", &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     okpx,
@@ -1584,7 +1584,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			"invalid key: overflowing coordinate",
 		}, {
 			"EC2 missing D", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2X:     ec256x,
@@ -1595,7 +1595,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			ErrNotPrivKey.Error(),
 		}, {
 			"EC2 unknown curve", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: 70,
 					KeyLabelEC2X:     ec256x,
@@ -1607,7 +1607,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			`unsupported curve "unknown curve value 70" for key type EC2`,
 		}, {
 			"EC2 incorrect x size", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2X:     ec384x,
@@ -1619,7 +1619,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			"invalid key: overflowing coordinate",
 		}, {
 			"EC2 incorrect y size", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2X:     ec256x,
@@ -1631,7 +1631,7 @@ func TestKey_PrivateKey(t *testing.T) {
 			"invalid key: overflowing coordinate",
 		}, {
 			"EC2 incorrect d size", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2X:     ec256x,
@@ -1670,7 +1670,7 @@ func TestKey_PublicKey(t *testing.T) {
 	}{
 		{
 			"CurveEd25519", &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 					KeyLabelOKPX:     okpx,
@@ -1680,7 +1680,7 @@ func TestKey_PublicKey(t *testing.T) {
 			"",
 		}, {
 			"CurveP256", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2X:     ec256x,
@@ -1695,7 +1695,7 @@ func TestKey_PublicKey(t *testing.T) {
 			"",
 		}, {
 			"CurveP384", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP384,
 					KeyLabelEC2X:     ec384x,
@@ -1710,7 +1710,7 @@ func TestKey_PublicKey(t *testing.T) {
 			"",
 		}, {
 			"CurveP521", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP521,
 					KeyLabelEC2X:     ec521x,
@@ -1725,19 +1725,19 @@ func TestKey_PublicKey(t *testing.T) {
 			"",
 		}, {
 			"unknown key type", &Key{
-				KeyType: KeyType(7),
+				Type: KeyType(7),
 			},
 			nil,
 			`unexpected key type "unknown key type value 7"`,
 		}, {
 			"invalid key type", &Key{
-				KeyType: KeyTypeInvalid,
+				Type: KeyTypeInvalid,
 			},
 			nil,
 			`invalid key: kty value 0`,
 		}, {
 			"OKP missing X", &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: CurveEd25519,
 				},
@@ -1746,7 +1746,7 @@ func TestKey_PublicKey(t *testing.T) {
 			ErrOKPNoPub.Error(),
 		}, {
 			"OKP unknown curve", &Key{
-				KeyType: KeyTypeOKP,
+				Type: KeyTypeOKP,
 				Params: map[interface{}]interface{}{
 					KeyLabelOKPCurve: 70,
 					KeyLabelOKPX:     okpx,
@@ -1756,7 +1756,7 @@ func TestKey_PublicKey(t *testing.T) {
 			`unsupported curve "unknown curve value 70" for key type OKP`,
 		}, {
 			"EC2 missing X", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2Y:     ec256y,
@@ -1766,7 +1766,7 @@ func TestKey_PublicKey(t *testing.T) {
 			ErrEC2NoPub.Error(),
 		}, {
 			"EC2 missing Y", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: CurveP256,
 					KeyLabelEC2X:     ec256x,
@@ -1776,7 +1776,7 @@ func TestKey_PublicKey(t *testing.T) {
 			ErrEC2NoPub.Error(),
 		}, {
 			"EC2 unknown curve", &Key{
-				KeyType: KeyTypeEC2,
+				Type: KeyTypeEC2,
 				Params: map[interface{}]interface{}{
 					KeyLabelEC2Curve: 70,
 					KeyLabelEC2X:     ec256x,

--- a/key_test.go
+++ b/key_test.go
@@ -1731,7 +1731,7 @@ func TestKey_PublicKey(t *testing.T) {
 			`unexpected key type "unknown key type value 7"`,
 		}, {
 			"invalid key type", &Key{
-				Type: KeyTypeInvalid,
+				Type: KeyTypeReserved,
 			},
 			nil,
 			`invalid key: kty value 0`,
@@ -1802,13 +1802,14 @@ func TestKey_PublicKey(t *testing.T) {
 }
 
 func TestKeyType_String(t *testing.T) {
-	// test string conversions not exercised by other test cases
 	tests := []struct {
 		kt   KeyType
 		want string
 	}{
+		{KeyTypeReserved, "Reserved"},
 		{KeyTypeOKP, "OKP"},
 		{KeyTypeEC2, "EC2"},
+		{KeyTypeSymmetric, "Symmetric"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {

--- a/key_test.go
+++ b/key_test.go
@@ -1832,6 +1832,7 @@ func TestCurve_String(t *testing.T) {
 		{CurveX448, "X448"},
 		{CurveEd25519, "Ed25519"},
 		{CurveEd448, "Ed448"},
+		{CurveReserved, "Reserved"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {


### PR DESCRIPTION
This PR contain the following changes:
- Renamed `NewXKey` to `NewKeyX`, being X the key type. This form is more idiomatic.
- Removed the `Key` prefix from Key properties. It is go-ish to avoid prefixing the name of a property with the name of the struct.
- Rename `XInvalid` to `XReserved`, being X `KeyType`, `Curve`, `KeyOp` and `Algorithm`. This makes our API more similar to the COSE spec naming.
- Added some tests and spec pointers.