### PR TITLE
Add support for RS256, RS384, RS512 constants

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -22,12 +22,6 @@ const (
 	// Requires an available crypto.SHA512.
 	AlgorithmPS512 Algorithm = -39
 
-	// RSASSA-PKCS1-v1_5 using SHA-256 by RFC 8812.
-	// Requires an available crypto.SHA256.
-	// TODO(hs): add a note that this can only be used with an
-	// externally supplied cose.Signer/Verifier
-	AlgorithmRS256 Algorithm = -257
-
 	// ECDSA w/ SHA-256 by RFC 8152.
 	// Requires an available crypto.SHA256.
 	AlgorithmES256 Algorithm = -7
@@ -53,6 +47,25 @@ const (
 	AlgorithmReserved Algorithm = 0
 )
 
+// Algorithms known, but not supported by this library.
+//
+// Signers and Verifiers requiring the algorithms below are not
+// directly supported by this library. They need to be provided
+// as an external [cose.Signer] or [cose.Verifier] implementation.
+//
+// An example use case where RS256 is allowed and used is in
+// WebAuthn: https://www.w3.org/TR/webauthn-2/#sctn-sample-registration.
+const (
+	// RSASSA-PKCS1-v1_5 using SHA-256 by RFC 8812.
+	AlgorithmRS256 Algorithm = -257
+
+	// RSASSA-PKCS1-v1_5 using SHA-384 by RFC 8812.
+	AlgorithmRS384 Algorithm = -258
+
+	// RSASSA-PKCS1-v1_5 using SHA-512 by RFC 8812.
+	AlgorithmRS512 Algorithm = -259
+)
+
 // Algorithm represents an IANA algorithm entry in the COSE Algorithms registry.
 //
 // # See Also
@@ -73,6 +86,10 @@ func (a Algorithm) String() string {
 		return "PS512"
 	case AlgorithmRS256:
 		return "RS256"
+	case AlgorithmRS384:
+		return "RS384"
+	case AlgorithmRS512:
+		return "RS512"
 	case AlgorithmES256:
 		return "ES256"
 	case AlgorithmES384:

--- a/algorithm.go
+++ b/algorithm.go
@@ -22,6 +22,12 @@ const (
 	// Requires an available crypto.SHA512.
 	AlgorithmPS512 Algorithm = -39
 
+	// RSASSA-PKCS1-v1_5 using SHA-256 by RFC 8812.
+	// Requires an available crypto.SHA256.
+	// TODO(hs): add a note that this can only be used with an
+	// externally supplied cose.Signer/Verifier
+	AlgorithmRS256 Algorithm = -257
+
 	// ECDSA w/ SHA-256 by RFC 8152.
 	// Requires an available crypto.SHA256.
 	AlgorithmES256 Algorithm = -7
@@ -65,6 +71,8 @@ func (a Algorithm) String() string {
 		return "PS384"
 	case AlgorithmPS512:
 		return "PS512"
+	case AlgorithmRS256:
+		return "RS256"
 	case AlgorithmES256:
 		return "ES256"
 	case AlgorithmES384:

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -18,6 +18,7 @@ func TestAlgorithm_String(t *testing.T) {
 		{AlgorithmPS256, "PS256"},
 		{AlgorithmPS384, "PS384"},
 		{AlgorithmPS512, "PS512"},
+		{AlgorithmRS256, "RS256"},
 		{AlgorithmES256, "ES256"},
 		{AlgorithmES384, "ES384"},
 		{AlgorithmES512, "ES512"},

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -19,6 +19,8 @@ func TestAlgorithm_String(t *testing.T) {
 		{AlgorithmPS384, "PS384"},
 		{AlgorithmPS512, "PS512"},
 		{AlgorithmRS256, "RS256"},
+		{AlgorithmRS384, "RS384"},
+		{AlgorithmRS512, "RS512"},
 		{AlgorithmES256, "ES256"},
 		{AlgorithmES384, "ES384"},
 		{AlgorithmES512, "ES512"},

--- a/conformance_test.go
+++ b/conformance_test.go
@@ -308,6 +308,8 @@ func mustNameToAlg(name string) cose.Algorithm {
 		return cose.AlgorithmPS384
 	case "PS512":
 		return cose.AlgorithmPS512
+	case "RS256":
+		return cose.AlgorithmRS256
 	case "ES256":
 		return cose.AlgorithmES256
 	case "ES384":

--- a/conformance_test.go
+++ b/conformance_test.go
@@ -310,6 +310,10 @@ func mustNameToAlg(name string) cose.Algorithm {
 		return cose.AlgorithmPS512
 	case "RS256":
 		return cose.AlgorithmRS256
+	case "RS384":
+		return cose.AlgorithmRS384
+	case "RS512":
+		return cose.AlgorithmRS512
 	case "ES256":
 		return cose.AlgorithmES256
 	case "ES384":

--- a/signer.go
+++ b/signer.go
@@ -88,9 +88,7 @@ func NewSigner(alg Algorithm, key crypto.Signer) (Signer, error) {
 		return &ed25519Signer{
 			key: key,
 		}, nil
-	case AlgorithmRS256, AlgorithmRS384, AlgorithmRS512:
-		return nil, fmt.Errorf("can't create new Signer for %s: %w", alg, ErrAlgorithmNotSupported)
 	default:
-		return nil, ErrAlgorithmNotSupported
+		return nil, fmt.Errorf("can't create new Signer for %s: %w", alg, ErrAlgorithmNotSupported)
 	}
 }

--- a/signer.go
+++ b/signer.go
@@ -88,8 +88,8 @@ func NewSigner(alg Algorithm, key crypto.Signer) (Signer, error) {
 		return &ed25519Signer{
 			key: key,
 		}, nil
-	case AlgorithmRS256:
-		return nil, fmt.Errorf("can't create Signer for %s: %w", alg, ErrAlgorithmNotSupported)
+	case AlgorithmRS256, AlgorithmRS384, AlgorithmRS512:
+		return nil, fmt.Errorf("can't create new Signer for %s: %w", alg, ErrAlgorithmNotSupported)
 	default:
 		return nil, ErrAlgorithmNotSupported
 	}

--- a/signer.go
+++ b/signer.go
@@ -88,6 +88,8 @@ func NewSigner(alg Algorithm, key crypto.Signer) (Signer, error) {
 		return &ed25519Signer{
 			key: key,
 		}, nil
+	case AlgorithmRS256:
+		return nil, fmt.Errorf("can't create Signer for %s: %w", alg, ErrAlgorithmNotSupported)
 	default:
 		return nil, ErrAlgorithmNotSupported
 	}

--- a/signer_test.go
+++ b/signer_test.go
@@ -111,6 +111,11 @@ func TestNewSigner(t *testing.T) {
 			wantErr: "RSA key must be at least 2048 bits long",
 		},
 		{
+			name:    "unsupported rsa signing algorithm",
+			alg:     AlgorithmRS256,
+			wantErr: "can't create Signer for RS256: algorithm not supported",
+		},
+		{
 			name:    "unknown algorithm",
 			alg:     0,
 			wantErr: "algorithm not supported",

--- a/signer_test.go
+++ b/signer_test.go
@@ -113,7 +113,7 @@ func TestNewSigner(t *testing.T) {
 		{
 			name:    "unsupported rsa signing algorithm",
 			alg:     AlgorithmRS256,
-			wantErr: "can't create Signer for RS256: algorithm not supported",
+			wantErr: "can't create new Signer for RS256: algorithm not supported",
 		},
 		{
 			name:    "unknown algorithm",

--- a/signer_test.go
+++ b/signer_test.go
@@ -118,7 +118,12 @@ func TestNewSigner(t *testing.T) {
 		{
 			name:    "unknown algorithm",
 			alg:     0,
-			wantErr: "algorithm not supported",
+			wantErr: "can't create new Signer for Reserved: algorithm not supported",
+		},
+		{
+			name:    "unassigned algorithm",
+			alg:     -1,
+			wantErr: "can't create new Signer for unknown algorithm value -1: algorithm not supported",
 		},
 	}
 	for _, tt := range tests {

--- a/verifier.go
+++ b/verifier.go
@@ -74,8 +74,8 @@ func NewVerifier(alg Algorithm, key crypto.PublicKey) (Verifier, error) {
 		return &ed25519Verifier{
 			key: vk,
 		}, nil
-	case AlgorithmRS256:
-		return nil, fmt.Errorf("can't create Verifier for %s: %w", alg, ErrAlgorithmNotSupported)
+	case AlgorithmRS256, AlgorithmRS384, AlgorithmRS512:
+		return nil, fmt.Errorf("can't create new Verifier for %s: %w", alg, ErrAlgorithmNotSupported)
 	default:
 		return nil, ErrAlgorithmNotSupported
 	}

--- a/verifier.go
+++ b/verifier.go
@@ -74,9 +74,7 @@ func NewVerifier(alg Algorithm, key crypto.PublicKey) (Verifier, error) {
 		return &ed25519Verifier{
 			key: vk,
 		}, nil
-	case AlgorithmRS256, AlgorithmRS384, AlgorithmRS512:
-		return nil, fmt.Errorf("can't create new Verifier for %s: %w", alg, ErrAlgorithmNotSupported)
 	default:
-		return nil, ErrAlgorithmNotSupported
+		return nil, fmt.Errorf("can't create new Verifier for %s: %w", alg, ErrAlgorithmNotSupported)
 	}
 }

--- a/verifier.go
+++ b/verifier.go
@@ -74,6 +74,8 @@ func NewVerifier(alg Algorithm, key crypto.PublicKey) (Verifier, error) {
 		return &ed25519Verifier{
 			key: vk,
 		}, nil
+	case AlgorithmRS256:
+		return nil, fmt.Errorf("can't create Verifier for %s: %w", alg, ErrAlgorithmNotSupported)
 	default:
 		return nil, ErrAlgorithmNotSupported
 	}

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -107,6 +107,11 @@ func TestNewVerifier(t *testing.T) {
 			wantErr: "RSA key must be at least 2048 bits long",
 		},
 		{
+			name:    "unsupported rsa signing algorithm",
+			alg:     AlgorithmRS256,
+			wantErr: "can't create Verifier for RS256: algorithm not supported",
+		},
+		{
 			name:    "unknown algorithm",
 			alg:     0,
 			wantErr: "algorithm not supported",

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -109,7 +109,7 @@ func TestNewVerifier(t *testing.T) {
 		{
 			name:    "unsupported rsa signing algorithm",
 			alg:     AlgorithmRS256,
-			wantErr: "can't create Verifier for RS256: algorithm not supported",
+			wantErr: "can't create new Verifier for RS256: algorithm not supported",
 		},
 		{
 			name:    "unknown algorithm",

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -114,7 +114,12 @@ func TestNewVerifier(t *testing.T) {
 		{
 			name:    "unknown algorithm",
 			alg:     0,
-			wantErr: "algorithm not supported",
+			wantErr: "can't create new Verifier for Reserved: algorithm not supported",
+		},
+		{
+			name:    "unassigned algorithm",
+			alg:     -1,
+			wantErr: "can't create new Verifier for unknown algorithm value -1: algorithm not supported",
 		},
 		{
 			name:    "bogus ecdsa public key (point not on curve)",


### PR DESCRIPTION
This PR replaces https://github.com/veraison/go-cose/pull/140. It closes https://github.com/veraison/go-cose/issues/141.

It only provides the constants for the algorithms. A `cose.Signer` or `cose.Verifier` needs to be implemented and provided from outside the package to use these algorithms. Using `NewSigner` and `NewVerifier` will return an error when called with one of these algorithms, because PKCS#1 v1.5 signing and verification aren't implemented in `go-cose` itself.

Example usage with external `mycose` package:
```golang
import (
        "crypto/rand"

	"github.com/veraison/go-cose"
	"go.step.sm/crypto/keyutil"
	
	"mycose"
)

func main(){
	key, _ := keyutil.GenerateSigner("RSA", "", 2048)
	cs := mycose.NewRS256Signer(key)  // adheres to cose.Signer

        data := []byte("1234")
	sig, _ := cs.Sign(rand.Reader, data)
	
	headers := cose.Headers{
		Protected: cose.ProtectedHeader{
			cose.HeaderLabelAlgorithm: cose.AlgorithmRS256,
		},
	}
	sig, _ = cose.Sign1(rand.Reader, cs, headers, data, nil)
	
}	
```