### PR TITLE
Improve Algorithm.String() message for unknown values

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -103,7 +103,7 @@ func (a Algorithm) String() string {
 	case AlgorithmReserved:
 		return "Reserved"
 	default:
-		return "unknown algorithm value " + strconv.Itoa(int(a))
+		return "Algorithm(" + strconv.Itoa(int(a)) + ")"
 	}
 }
 

--- a/algorithm_test.go
+++ b/algorithm_test.go
@@ -26,7 +26,7 @@ func TestAlgorithm_String(t *testing.T) {
 		{AlgorithmES512, "ES512"},
 		{AlgorithmEdDSA, "EdDSA"},
 		{AlgorithmReserved, "Reserved"},
-		{7, "unknown algorithm value 7"},
+		{7, "Algorithm(7)"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {

--- a/headers.go
+++ b/headers.go
@@ -119,7 +119,7 @@ func (h ProtectedHeader) Algorithm() (Algorithm, error) {
 	case int64:
 		return Algorithm(alg), nil
 	case string:
-		return AlgorithmReserved, fmt.Errorf("unknown algorithm value %q", alg)
+		return AlgorithmReserved, fmt.Errorf("Algorithm(%q)", alg)
 	default:
 		return AlgorithmReserved, ErrInvalidAlgorithm
 	}

--- a/headers_test.go
+++ b/headers_test.go
@@ -423,7 +423,7 @@ func TestProtectedHeader_Algorithm(t *testing.T) {
 			h: ProtectedHeader{
 				HeaderLabelAlgorithm: "foo",
 			},
-			wantErr: errors.New("unknown algorithm value \"foo\""),
+			wantErr: errors.New("Algorithm(\"foo\")"),
 		},
 		{
 			name: "invalid algorithm",

--- a/key_test.go
+++ b/key_test.go
@@ -861,7 +861,7 @@ func TestNewKeyOKP(t *testing.T) {
 		}, {
 			name: "invalid alg", args: args{Algorithm(-100), x, d},
 			want:    nil,
-			wantErr: `unsupported algorithm "unknown algorithm value -100"`,
+			wantErr: `unsupported algorithm "Algorithm(-100)"`,
 		}, {
 			name: "x and d missing", args: args{AlgorithmEdDSA, nil, nil},
 			want:    nil,
@@ -940,7 +940,7 @@ func TestNewNewKeyEC2(t *testing.T) {
 		}, {
 			name: "invalid alg", args: args{Algorithm(-100), ec256x, ec256y, ec256d},
 			want:    nil,
-			wantErr: `unsupported algorithm "unknown algorithm value -100"`,
+			wantErr: `unsupported algorithm "Algorithm(-100)"`,
 		}, {
 			name: "x, y and d missing", args: args{AlgorithmES512, nil, nil, nil},
 			want:    nil,

--- a/signer.go
+++ b/signer.go
@@ -50,6 +50,7 @@ type DigestSigner interface {
 // Note: `*rsa.PrivateKey`, `*ecdsa.PrivateKey`, and `ed25519.PrivateKey`
 // implement `crypto.Signer`.
 func NewSigner(alg Algorithm, key crypto.Signer) (Signer, error) {
+	var errReason string
 	switch alg {
 	case AlgorithmPS256, AlgorithmPS384, AlgorithmPS512:
 		vk, ok := key.Public().(*rsa.PublicKey)
@@ -88,7 +89,12 @@ func NewSigner(alg Algorithm, key crypto.Signer) (Signer, error) {
 		return &ed25519Signer{
 			key: key,
 		}, nil
+	case AlgorithmReserved:
+		errReason = "can't be implemented"
+	case AlgorithmRS256, AlgorithmRS384, AlgorithmRS512:
+		errReason = "no built-in implementation available"
 	default:
-		return nil, fmt.Errorf("can't create new Signer for %s: %w", alg, ErrAlgorithmNotSupported)
+		errReason = "unknown algorithm"
 	}
+	return nil, fmt.Errorf("can't create new Signer for %s: %s: %w", alg, errReason, ErrAlgorithmNotSupported)
 }

--- a/signer_test.go
+++ b/signer_test.go
@@ -113,17 +113,17 @@ func TestNewSigner(t *testing.T) {
 		{
 			name:    "unsupported rsa signing algorithm",
 			alg:     AlgorithmRS256,
-			wantErr: "can't create new Signer for RS256: algorithm not supported",
+			wantErr: "can't create new Signer for RS256: no built-in implementation available: algorithm not supported",
 		},
 		{
-			name:    "unknown algorithm",
-			alg:     0,
-			wantErr: "can't create new Signer for Reserved: algorithm not supported",
+			name:    "reserved algorithm",
+			alg:     AlgorithmReserved,
+			wantErr: "can't create new Signer for Reserved: can't be implemented: algorithm not supported",
 		},
 		{
 			name:    "unassigned algorithm",
 			alg:     -1,
-			wantErr: "can't create new Signer for unknown algorithm value -1: algorithm not supported",
+			wantErr: "can't create new Signer for Algorithm(-1): unknown algorithm: algorithm not supported",
 		},
 	}
 	for _, tt := range tests {

--- a/verifier.go
+++ b/verifier.go
@@ -39,6 +39,7 @@ type DigestVerifier interface {
 //
 // The returned signer for rsa and ecdsa keys also implements `cose.DigestSigner`.
 func NewVerifier(alg Algorithm, key crypto.PublicKey) (Verifier, error) {
+	var errReason string
 	switch alg {
 	case AlgorithmPS256, AlgorithmPS384, AlgorithmPS512:
 		vk, ok := key.(*rsa.PublicKey)
@@ -74,7 +75,12 @@ func NewVerifier(alg Algorithm, key crypto.PublicKey) (Verifier, error) {
 		return &ed25519Verifier{
 			key: vk,
 		}, nil
+	case AlgorithmReserved:
+		errReason = "can't be implemented"
+	case AlgorithmRS256, AlgorithmRS384, AlgorithmRS512:
+		errReason = "no built-in implementation available"
 	default:
-		return nil, fmt.Errorf("can't create new Verifier for %s: %w", alg, ErrAlgorithmNotSupported)
+		errReason = "unknown algorithm"
 	}
+	return nil, fmt.Errorf("can't create new Verifier for %s: %s: %w", alg, errReason, ErrAlgorithmNotSupported)
 }

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -109,17 +109,17 @@ func TestNewVerifier(t *testing.T) {
 		{
 			name:    "unsupported rsa signing algorithm",
 			alg:     AlgorithmRS256,
-			wantErr: "can't create new Verifier for RS256: algorithm not supported",
+			wantErr: "can't create new Verifier for RS256: no built-in implementation available: algorithm not supported",
 		},
 		{
-			name:    "unknown algorithm",
-			alg:     0,
-			wantErr: "can't create new Verifier for Reserved: algorithm not supported",
+			name:    "reserved algorithm",
+			alg:     AlgorithmReserved,
+			wantErr: "can't create new Verifier for Reserved: can't be implemented: algorithm not supported",
 		},
 		{
 			name:    "unassigned algorithm",
 			alg:     -1,
-			wantErr: "can't create new Verifier for unknown algorithm value -1: algorithm not supported",
+			wantErr: "can't create new Verifier for Algorithm(-1): unknown algorithm: algorithm not supported",
 		},
 		{
 			name:    "bogus ecdsa public key (point not on curve)",


### PR DESCRIPTION
This PR modifies the `Algorithm.String` message for values not defined in go-cose.

For example, when calling `Algorithm(7).String()`, it previously returned `unknown algorithm value 7`. Considering that other libraries can define their own algorithms, IMO that message is too verbose and seems more like an error than a useful name.
With the new behavior, the returned string will be `Algorithm(7)`.

While here, fix #164.