### PR TITLE
chore: migrate to crypto/ecdh

### DIFF
--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -172,18 +172,6 @@ func generateTestECDSAKey(t *testing.T) *ecdsa.PrivateKey {
 	return key
 }
 
-func Test_customCurveKeySigner(t *testing.T) {
-	// https://github.com/veraison/go-cose/issues/59
-	pCustom := *elliptic.P256().Params()
-	pCustom.Name = "P-custom"
-	pCustom.BitSize /= 2
-	key, err := ecdsa.GenerateKey(&pCustom, rand.Reader)
-	if err != nil {
-		t.Fatalf("ecdsa.GenerateKey() error = %v", err)
-	}
-	testSignVerify(t, AlgorithmES256, key, false)
-}
-
 func Test_ecdsaKeySigner(t *testing.T) {
 	key := generateTestECDSAKey(t)
 	testSignVerify(t, AlgorithmES256, key, false)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/veraison/go-cose
 
-go 1.18
+go 1.21
 
 require github.com/fxamacker/cbor/v2 v2.5.0
 

--- a/verifier.go
+++ b/verifier.go
@@ -36,6 +36,8 @@ type DigestVerifier interface {
 // NewVerifier returns a verifier with a given public key.
 // Only golang built-in crypto public keys of type `*rsa.PublicKey`,
 // `*ecdsa.PublicKey`, and `ed25519.PublicKey` are accepted.
+// When `*ecdsa.PublicKey` is specified, its curve must be supported by
+// crypto/ecdh.
 //
 // The returned signer for rsa and ecdsa keys also implements `cose.DigestSigner`.
 func NewVerifier(alg Algorithm, key crypto.PublicKey) (Verifier, error) {
@@ -60,8 +62,11 @@ func NewVerifier(alg Algorithm, key crypto.PublicKey) (Verifier, error) {
 		if !ok {
 			return nil, fmt.Errorf("%v: %w", alg, ErrInvalidPubKey)
 		}
-		if !vk.Curve.IsOnCurve(vk.X, vk.Y) {
-			return nil, errors.New("public key point is not on curve")
+		if _, err := vk.ECDH(); err != nil {
+			if err.Error() == "ecdsa: invalid public key" {
+				return nil, fmt.Errorf("%v: %w", alg, ErrInvalidPubKey)
+			}
+			return nil, fmt.Errorf("%v: %w: %v", alg, ErrInvalidPubKey, err)
 		}
 		return &ecdsaVerifier{
 			alg: alg,

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -48,6 +48,13 @@ func TestNewVerifier(t *testing.T) {
 	// craft an EC public key with the x-coord not on curve
 	ecdsaKeyPointNotOnCurve := generateBogusECKey()
 
+	// craft an EC public key with a curve not supported by crypto/ecdh
+	ecdsaKeyUnsupportedCurve := &ecdsa.PublicKey{
+		Curve: ecdsaKey.Curve.Params(),
+		X:     ecdsaKey.X,
+		Y:     ecdsaKey.Y,
+	}
+
 	// run tests
 	tests := []struct {
 		name    string
@@ -125,7 +132,13 @@ func TestNewVerifier(t *testing.T) {
 			name:    "bogus ecdsa public key (point not on curve)",
 			alg:     AlgorithmES256,
 			key:     ecdsaKeyPointNotOnCurve,
-			wantErr: "public key point is not on curve",
+			wantErr: "ES256: invalid public key",
+		},
+		{
+			name:    "ecdsa public key with unsupported curve",
+			alg:     AlgorithmES256,
+			key:     ecdsaKeyUnsupportedCurve,
+			wantErr: "ES256: invalid public key: ecdsa: unsupported curve by crypto/ecdh",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Resolves #168 by migrating to `crypto/ecdh`.

Here are notable changes:
- Since `crypto/ecdh` is introduced in `go 1.21`, the minimum go version is thus bumped to `1.21` from `1.18`.
- Since `crypto/ecdh` does not expose low-level elliptic curve operations, custom curves are no longer supported. Thus the related test case is removed. /cc @qmuntal 
