### PR TITLE
chore: fix duplicated import in the example

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha512"
-	_ "crypto/sha512"
 	"fmt"
 
 	"github.com/veraison/go-cose"


### PR DESCRIPTION
Remove the duplicated imports