### PR TITLE
docs: fix the syntax of CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # To be kept in sync with: [community/OWNERS](https://github.com/veraison/community/blob/main/OWNERS) 
 # and the GitHub Team: [go-cose-maintainers](https://github.com/orgs/veraison/teams/go-cose-maintainers)
 
-* henkbirkholz qmuntal roywill setrofim shizhMSFT simonfrost-arm SteveLasker thomas-fossati yogeshbdeshpande 
+* @henkbirkholz @qmuntal @roywill @setrofim @shizhMSFT @simonfrost-arm @SteveLasker @thomas-fossati @yogeshbdeshpande


### PR DESCRIPTION
Fix the syntax error as there should be an `@` before the usernames.