### PR TITLE
refactor!: deprecate crypto elliptic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18, 1.19]
+        go-version: [1.21, 1.22]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -172,18 +172,6 @@ func generateTestECDSAKey(t *testing.T) *ecdsa.PrivateKey {
 	return key
 }
 
-func Test_customCurveKeySigner(t *testing.T) {
-	// https://github.com/veraison/go-cose/issues/59
-	pCustom := *elliptic.P256().Params()
-	pCustom.Name = "P-custom"
-	pCustom.BitSize /= 2
-	key, err := ecdsa.GenerateKey(&pCustom, rand.Reader)
-	if err != nil {
-		t.Fatalf("ecdsa.GenerateKey() error = %v", err)
-	}
-	testSignVerify(t, AlgorithmES256, key, false)
-}
-
 func Test_ecdsaKeySigner(t *testing.T) {
 	key := generateTestECDSAKey(t)
 	testSignVerify(t, AlgorithmES256, key, false)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/veraison/go-cose
 
-go 1.18
+go 1.21
 
 require github.com/fxamacker/cbor/v2 v2.5.0
 

--- a/key_test.go
+++ b/key_test.go
@@ -1487,15 +1487,8 @@ func TestKey_PrivateKey(t *testing.T) {
 					KeyLabelEC2D:     ec256d,
 				},
 			},
-			&ecdsa.PrivateKey{
-				PublicKey: ecdsa.PublicKey{
-					Curve: elliptic.P256(),
-					X:     new(big.Int).SetBytes(ec256x),
-					Y:     new(big.Int).SetBytes(ec256y),
-				},
-				D: new(big.Int).SetBytes(ec256d),
-			},
-			"",
+			nil,
+			"invalid private key: compressed point not supported",
 		}, {
 			"CurveP384", &Key{
 				Type: KeyTypeEC2,

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -48,6 +48,13 @@ func TestNewVerifier(t *testing.T) {
 	// craft an EC public key with the x-coord not on curve
 	ecdsaKeyPointNotOnCurve := generateBogusECKey()
 
+	// craft an EC public key with a curve not supported by crypto/ecdh
+	ecdsaKeyUnsupportedCurve := &ecdsa.PublicKey{
+		Curve: ecdsaKey.Curve.Params(),
+		X:     ecdsaKey.X,
+		Y:     ecdsaKey.Y,
+	}
+
 	// run tests
 	tests := []struct {
 		name    string
@@ -125,7 +132,13 @@ func TestNewVerifier(t *testing.T) {
 			name:    "bogus ecdsa public key (point not on curve)",
 			alg:     AlgorithmES256,
 			key:     ecdsaKeyPointNotOnCurve,
-			wantErr: "public key point is not on curve",
+			wantErr: "ES256: invalid public key",
+		},
+		{
+			name:    "ecdsa public key with unsupported curve",
+			alg:     AlgorithmES256,
+			key:     ecdsaKeyUnsupportedCurve,
+			wantErr: "ES256: invalid public key: ecdsa: unsupported curve by crypto/ecdh",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Resolves #168, resolves #185.

Breaking changes:
- Remove compressed point support from EC2 keys

Other changes:
- Remove calls to deprecated functions in `crypto/elliptic`
- Upgrade golang to 1.21 for `crypto/ecdh`

Related:
- #178