### PR TITLE
feat: support detached payloads in COSESign and COSESign1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ vendor/
 
 # Editor files
 .vscode/
+.idea/

--- a/errors.go
+++ b/errors.go
@@ -10,6 +10,7 @@ var (
 	ErrEmptySignature        = errors.New("empty signature")
 	ErrInvalidAlgorithm      = errors.New("invalid algorithm")
 	ErrMissingPayload        = errors.New("missing payload")
+	ErrMultiplePayloads      = errors.New("multiple payloads")
 	ErrNoSignatures          = errors.New("no signatures attached")
 	ErrUnavailableHashFunc   = errors.New("hash function is not available")
 	ErrVerification          = errors.New("verification error")

--- a/sign.go
+++ b/sign.go
@@ -490,7 +490,9 @@ func (m *SignMessage) VerifyDetached(detached, external []byte, verifiers ...Ver
 	if detached == nil {
 		return ErrMissingPayload
 	}
-	return m.verify(detached, external, verifiers...)
+	msg := *m
+	msg.Payload = detached
+	return msg.Verify(external, verifiers...)
 }
 
 func (m *SignMessage) verify(detached, external []byte, verifiers ...Verifier) error {

--- a/sign.go
+++ b/sign.go
@@ -398,12 +398,37 @@ func (m *SignMessage) UnmarshalCBOR(data []byte) error {
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
 func (m *SignMessage) Sign(rand io.Reader, external []byte, signers ...Signer) error {
+	return m.sign(rand, nil, external, signers)
+}
+
+// SignDetached signs a SignMessage using the provided signers corresponding to the
+// signatures.
+//
+// See `Signature.Sign()` for advanced signing scenarios.
+//
+// Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
+//
+// # Experimental
+//
+// Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func (m *SignMessage) SignDetached(rand io.Reader, detached, external []byte, signers ...Signer) error {
+	if detached == nil {
+		return ErrMissingPayload
+	}
+	return m.sign(rand, detached, external, signers)
+}
+
+func (m *SignMessage) sign(rand io.Reader, detached, external []byte, signers []Signer) error {
 	if m == nil {
 		return errors.New("signing nil SignMessage")
 	}
-	if m.Payload == nil {
-		return ErrMissingPayload
+
+	payload, err := checkPayload(m.Payload, detached)
+	if err != nil {
+		return err
 	}
+
 	switch len(m.Signatures) {
 	case 0:
 		return ErrNoSignatures
@@ -415,14 +440,14 @@ func (m *SignMessage) Sign(rand io.Reader, external []byte, signers ...Signer) e
 
 	// populate common parameters
 	var protected cbor.RawMessage
-	protected, err := m.Headers.MarshalProtected()
+	protected, err = m.Headers.MarshalProtected()
 	if err != nil {
 		return err
 	}
 
 	// sign message accordingly
 	for i, signature := range m.Signatures {
-		if err := signature.Sign(rand, signers[i], protected, m.Payload, external); err != nil {
+		if err := signature.Sign(rand, signers[i], protected, payload, external); err != nil {
 			return err
 		}
 	}
@@ -443,12 +468,41 @@ func (m *SignMessage) Sign(rand io.Reader, external []byte, signers ...Signer) e
 // Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
 // later release.
 func (m *SignMessage) Verify(external []byte, verifiers ...Verifier) error {
+	return m.verify(nil, external, verifiers...)
+}
+
+// VerifyDetached verifies the signatures on the SignMessage against the corresponding
+// verifier, returning nil on success or a suitable error if verification fails.
+//
+// Returns ErrMissingPayload if detached is nil, and ErrMultiplePayloads if the SignMessage
+// also has an attached payload.
+//
+// See `Signature.Verify()` for advanced verification scenarios like threshold
+// policies.
+//
+// Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
+//
+// # Experimental
+//
+// Notice: The COSE Sign API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func (m *SignMessage) VerifyDetached(detached, external []byte, verifiers ...Verifier) error {
+	if detached == nil {
+		return ErrMissingPayload
+	}
+	return m.verify(detached, external, verifiers...)
+}
+
+func (m *SignMessage) verify(detached, external []byte, verifiers ...Verifier) error {
 	if m == nil {
 		return errors.New("verifying nil SignMessage")
 	}
-	if m.Payload == nil {
-		return ErrMissingPayload
+
+	payload, err := checkPayload(m.Payload, detached)
+	if err != nil {
+		return err
 	}
+
 	switch len(m.Signatures) {
 	case 0:
 		return ErrNoSignatures
@@ -460,16 +514,31 @@ func (m *SignMessage) Verify(external []byte, verifiers ...Verifier) error {
 
 	// populate common parameters
 	var protected cbor.RawMessage
-	protected, err := m.Headers.MarshalProtected()
+	protected, err = m.Headers.MarshalProtected()
 	if err != nil {
 		return err
 	}
 
 	// verify message accordingly
 	for i, signature := range m.Signatures {
-		if err := signature.Verify(verifiers[i], protected, m.Payload, external); err != nil {
+		if err := signature.Verify(verifiers[i], protected, payload, external); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// checkPayload checks that exactly one of payload and detached is non-nil.
+func checkPayload(payload, detached []byte) ([]byte, error) {
+	if detached != nil {
+		if payload != nil {
+			return nil, ErrMultiplePayloads
+		}
+		return detached, nil
+	}
+
+	if payload == nil {
+		return nil, ErrMissingPayload
+	}
+	return payload, nil
 }

--- a/sign1_test.go
+++ b/sign1_test.go
@@ -967,7 +967,7 @@ func TestSign1Message_toBeSigned(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.m.toBeSigned(tt.external)
+			got, err := tt.m.toBeSigned(tt.external, tt.m.Payload)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Sign1Message.toBeSigned() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Hey,

I've extended COSESign and COSESign1 to support detached payloads, adds a parameter to the public API, not sure if that's desirable.

I'm also pretty new to Go, I've tried to copy the existing style but I'm sure there's plenty that could be improved.

Cheers, Alex

https://github.com/veraison/go-cose/issues/195