### PR TITLE
build: fix codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,6 @@ jobs:
     - name: Run tests
       run: go test -race -v -coverprofile=coverage.txt .
     - name: Upload coverage to codecov.io
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fix #199 
- upgrade `codecov-action` to `v4`
- provide `CODECOV_TOKEN`