### PR TITLE
fix: fix overflow of unknown values

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -103,7 +103,7 @@ func (a Algorithm) String() string {
 	case AlgorithmReserved:
 		return "Reserved"
 	default:
-		return "Algorithm(" + strconv.Itoa(int(a)) + ")"
+		return "Algorithm(" + strconv.FormatInt(int64(a), 10) + ")"
 	}
 }
 

--- a/key.go
+++ b/key.go
@@ -130,7 +130,7 @@ func (ko KeyOp) String() string {
 	case KeyOpReserved:
 		return "Reserved"
 	default:
-		return "unknown key_op value " + strconv.Itoa(int(ko))
+		return "unknown key_op value " + strconv.FormatInt(int64(ko), 10)
 	}
 }
 
@@ -160,7 +160,7 @@ func (kt KeyType) String() string {
 	case KeyTypeReserved:
 		return "Reserved"
 	default:
-		return "unknown key type value " + strconv.Itoa(int(kt))
+		return "unknown key type value " + strconv.FormatInt(int64(kt), 10)
 	}
 }
 
@@ -217,7 +217,7 @@ func (c Curve) String() string {
 	case CurveReserved:
 		return "Reserved"
 	default:
-		return "unknown curve value " + strconv.Itoa(int(c))
+		return "unknown curve value " + strconv.FormatInt(int64(c), 10)
 	}
 }
 


### PR DESCRIPTION
Fix potential overflow when printing the error message of unknown values.