### PR TITLE
docs: improve code documentation

### DIFF
--- a/algorithm.go
+++ b/algorithm.go
@@ -36,7 +36,7 @@ const (
 
 	// PureEdDSA by RFC 8152.
 	//
-	// Deprecated: use AlgorithmEdDSA instead, which has
+	// Deprecated: use [AlgorithmEdDSA] instead, which has
 	// the same value but with a more accurate name.
 	AlgorithmEd25519 Algorithm = -8
 
@@ -51,7 +51,7 @@ const (
 //
 // Signers and Verifiers requiring the algorithms below are not
 // directly supported by this library. They need to be provided
-// as an external [cose.Signer] or [cose.Verifier] implementation.
+// as an external [Signer] or [Verifier] implementation.
 //
 // An example use case where RS256 is allowed and used is in
 // WebAuthn: https://www.w3.org/TR/webauthn-2/#sctn-sample-registration.
@@ -72,7 +72,7 @@ const (
 //
 // COSE Algorithms: https://www.iana.org/assignments/cose/cose.xhtml#algorithms
 //
-// RFC 8152 16.4: https://datatracker.ietf.org/doc/html/rfc8152#section-16.4
+// RFC 8152 section 16.4: https://datatracker.ietf.org/doc/html/rfc8152#section-16.4
 type Algorithm int64
 
 // String returns the name of the algorithm
@@ -97,8 +97,8 @@ func (a Algorithm) String() string {
 	case AlgorithmES512:
 		return "ES512"
 	case AlgorithmEdDSA:
-		// As stated in RFC 8152 8.2, only the pure EdDSA version is used for
-		// COSE.
+		// As stated in RFC 8152 section 8.2, only the pure EdDSA version is
+		// used for COSE.
 		return "EdDSA"
 	case AlgorithmReserved:
 		return "Reserved"

--- a/cbor.go
+++ b/cbor.go
@@ -122,7 +122,7 @@ func deterministicBinaryString(data cbor.RawMessage) (cbor.RawMessage, error) {
 	}
 
 	// slow path: convert by re-encoding
-	// error checking is not required since `data` has been validataed
+	// error checking is not required since `data` has been validated
 	var s []byte
 	_ = decModeWithTagsForbidden.Unmarshal(data, &s)
 	return encMode.Marshal(s)

--- a/countersign.go
+++ b/countersign.go
@@ -95,8 +95,8 @@ func (s *Countersignature) Sign(rand io.Reader, signer Signer, parent any, exter
 	return nil
 }
 
-// Verify verifies the countersignature, returning nil on success or a suitable error
-// if verification fails.
+// Verify verifies the countersignature, returning nil on success or a suitable
+// error if verification fails.
 // Verifying a COSE_Countersignature requires the parent message.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
@@ -141,11 +141,13 @@ func (s *Countersignature) toBeSigned(target any, external []byte) ([]byte, erro
 	return countersignToBeSigned(false, target, signProtected, external)
 }
 
-// countersignToBeSigned constructs Countersign_structure, computes and returns ToBeSigned.
+// countersignToBeSigned constructs Countersign_structure, computes and returns
+// ToBeSigned.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc9338#section-3.3
 func countersignToBeSigned(abbreviated bool, target any, signProtected cbor.RawMessage, external []byte) ([]byte, error) {
-	// create a Countersign_structure and populate it with the appropriate fields.
+	// create a Countersign_structure and populate it with the appropriate
+	// fields.
 	//
 	//   Countersign_structure = [
 	//       context : "CounterSignature" / "CounterSignature0" /
@@ -263,8 +265,8 @@ func countersignToBeSigned(abbreviated bool, target any, signProtected cbor.RawM
 		countersigStructure = append(countersigStructure, otherFields)
 	}
 
-	// create the value ToBeSigned by encoding the Countersign_structure to a byte
-	// string.
+	// create the value ToBeSigned by encoding the Countersign_structure to a
+	// byte string.
 	return encMode.Marshal(countersigStructure)
 }
 

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -158,7 +158,7 @@ func (ev *ecdsaVerifier) Algorithm() Algorithm {
 
 // Verify verifies message content with the public key, returning nil for
 // success.
-// Otherwise, it returns ErrVerification.
+// Otherwise, it returns [ErrVerification].
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8.1
 func (ev *ecdsaVerifier) Verify(content []byte, signature []byte) error {
@@ -172,7 +172,7 @@ func (ev *ecdsaVerifier) Verify(content []byte, signature []byte) error {
 
 // VerifyDigest verifies message digest with the public key, returning nil
 // for success.
-// Otherwise, it returns ErrVerification.
+// Otherwise, it returns [ErrVerification].
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8.1
 func (ev *ecdsaVerifier) VerifyDigest(digest []byte, signature []byte) error {

--- a/ed25519.go
+++ b/ed25519.go
@@ -39,7 +39,7 @@ func (ev *ed25519Verifier) Algorithm() Algorithm {
 
 // Verify verifies message content with the public key, returning nil for
 // success.
-// Otherwise, it returns ErrVerification.
+// Otherwise, it returns [ErrVerification].
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8.2
 func (ev *ed25519Verifier) Verify(content []byte, signature []byte) error {

--- a/headers.go
+++ b/headers.go
@@ -170,7 +170,8 @@ func (h ProtectedHeader) Critical() ([]any, error) {
 	return value.([]any), nil
 }
 
-// ensureCritical ensures all critical headers are present in the protected bucket.
+// ensureCritical ensures all critical headers are present in the protected
+// bucket.
 func ensureCritical(value any, headers map[any]any) error {
 	labels, ok := value.([]any)
 	if !ok {

--- a/key.go
+++ b/key.go
@@ -100,11 +100,11 @@ func KeyOpFromString(val string) (KeyOp, bool) {
 	}
 }
 
-// String returns a string representation of the KeyType. Note does not
+// String returns a string representation of the KeyOp. Note does not
 // represent a valid value  of the corresponding serialized entry, and must not
 // be used as such. (The values returned _mostly_ correspond to those accepted
 // by KeyOpFromString, except for MAC create/verify, which are not defined by
-// RFC7517).
+// RFC 7517).
 func (ko KeyOp) String() string {
 	switch ko {
 	case KeyOpSign:
@@ -147,8 +147,8 @@ const (
 )
 
 // String returns a string representation of the KeyType. Note does not
-// represent a valid value  of the corresponding serialized entry, and must
-// not be used as such.
+// represent a valid value of the corresponding serialized entry, and must not
+// be used as such.
 func (kt KeyType) String() string {
 	switch kt {
 	case KeyTypeOKP:
@@ -196,8 +196,8 @@ const (
 )
 
 // String returns a string representation of the Curve. Note does not
-// represent a valid value  of the corresponding serialized entry, and must
-// not be used as such.
+// represent a valid value of the corresponding serialized entry, and must not
+// be used as such.
 func (c Curve) String() string {
 	switch c {
 	case CurveP256:
@@ -221,8 +221,8 @@ func (c Curve) String() string {
 	}
 }
 
-// Key represents a COSE_Key structure, as defined by RFC8152.
-// Note: currently, this does NOT support RFC8230 (RSA algorithms).
+// Key represents a COSE_Key structure, as defined by RFC 8152.
+// Note: currently, this does NOT support RFC 8230 (RSA algorithms).
 type Key struct {
 	// Type identifies the family of keys for this structure, and thus,
 	// which of the key-type-specific parameters need to be set.
@@ -380,8 +380,8 @@ func (key *Key) Symmetric() (k []byte) {
 	return
 }
 
-// NewKeyFromPublic returns a Key created using the provided crypto.PublicKey.
-// Supported key formats are: *ecdsa.PublicKey and ed25519.PublicKey
+// NewKeyFromPublic returns a Key created using the provided [crypto.PublicKey].
+// Supported key formats are: [*ecdsa.PublicKey] and [ed25519.PublicKey].
 func NewKeyFromPublic(pub crypto.PublicKey) (*Key, error) {
 	switch vk := pub.(type) {
 	case *ecdsa.PublicKey:
@@ -399,8 +399,8 @@ func NewKeyFromPublic(pub crypto.PublicKey) (*Key, error) {
 	}
 }
 
-// NewKeyFromPrivate returns a Key created using provided crypto.PrivateKey.
-// Supported key formats are: *ecdsa.PrivateKey and ed25519.PrivateKey
+// NewKeyFromPrivate returns a Key created using provided [crypto.PrivateKey].
+// Supported key formats are: [*ecdsa.PrivateKey] and [ed25519.PrivateKey].
 func NewKeyFromPrivate(priv crypto.PrivateKey) (*Key, error) {
 	switch sk := priv.(type) {
 	case *ecdsa.PrivateKey:
@@ -448,10 +448,10 @@ func (k Key) validate(op KeyOp) error {
 			return errReqParamsMissing
 		}
 		if size := curveSize(crv); size > 0 {
-			// RFC 8152 Section 13.1.1 says that x and y leading zero octets MUST be preserved,
-			// but the Go crypto/elliptic package trims them. So we relax the check
-			// here to allow for omitted leading zero octets, we will add them back
-			// when marshaling.
+			// RFC 8152 Section 13.1.1 says that x and y leading zero octets
+			// MUST be preserved, but the Go crypto/elliptic package trims them.
+			// So we relax the check here to allow for omitted leading zero
+			// octets, we will add them back when marshaling.
 			if len(x) > size || len(y) > size || len(d) > size {
 				return errCoordOverflow
 			}
@@ -653,7 +653,7 @@ func (k *Key) UnmarshalCBOR(data []byte) error {
 	return k.validate(KeyOpReserved)
 }
 
-// PublicKey returns a crypto.PublicKey generated using Key's parameters.
+// PublicKey returns a [crypto.PublicKey] generated using Key's parameters.
 func (k *Key) PublicKey() (crypto.PublicKey, error) {
 	if err := k.validate(KeyOpVerify); err != nil {
 		return nil, err
@@ -691,7 +691,7 @@ func (k *Key) PublicKey() (crypto.PublicKey, error) {
 	}
 }
 
-// PrivateKey returns a crypto.PrivateKey generated using Key's parameters.
+// PrivateKey returns a [crypto.PrivateKey] generated using Key's parameters.
 // Compressed point is not supported for EC2 keys.
 func (k *Key) PrivateKey() (crypto.PrivateKey, error) {
 	if err := k.validate(KeyOpSign); err != nil {
@@ -744,10 +744,10 @@ func (k *Key) PrivateKey() (crypto.PrivateKey, error) {
 	}
 }
 
-// AlgorithmOrDefault returns the Algorithm associated with Key. If Key.Algorithm is
-// set, that is what is returned. Otherwise, the algorithm is inferred using
-// Key.Curve. This method does NOT validate that Key.Algorithm, if set, aligns
-// with Key.Curve.
+// AlgorithmOrDefault returns the Algorithm associated with Key. If
+// Key.Algorithm is set, that is what is returned. Otherwise, the algorithm is
+// inferred using Key.Curve. This method does NOT validate that Key.Algorithm,
+// if set, aligns with Key.Curve.
 func (k *Key) AlgorithmOrDefault() (Algorithm, error) {
 	if k.Algorithm != AlgorithmReserved {
 		return k.Algorithm, nil
@@ -798,7 +798,7 @@ func (k *Key) Verifier() (Verifier, error) {
 }
 
 // deriveAlgorithm derives the intended algorithm for the key from its curve.
-// The deriviation is based on the recommendation in RFC8152 that SHA-256 is
+// The derivation is based on the recommendation in RFC 8152 that SHA-256 is
 // only used with P-256, etc. For other combinations, the Algorithm in the Key
 // must be explicitly set,so that this derivation is not used.
 func (k *Key) deriveAlgorithm() (Algorithm, error) {
@@ -826,7 +826,7 @@ func (k *Key) deriveAlgorithm() (Algorithm, error) {
 				"unsupported curve %q for key type OKP", crv.String())
 		}
 	default:
-		// Symmetric algorithms are not supported in the current inmplementation.
+		// Symmetric algorithms are not supported in the current implementation.
 		return AlgorithmReserved, fmt.Errorf("unexpected key type %q", k.Type.String())
 	}
 }

--- a/rsa.go
+++ b/rsa.go
@@ -6,7 +6,7 @@ import (
 	"io"
 )
 
-// rsaSigner is a RSASSA-PSS based signer with a generic crypto.Signer.
+// rsaSigner is a RSASSA-PSS based signer with a generic [crypto.Signer].
 //
 // Reference: https://www.rfc-editor.org/rfc/rfc8230.html#section-2
 type rsaSigner struct {
@@ -56,7 +56,7 @@ func (rv *rsaVerifier) Algorithm() Algorithm {
 
 // Verify verifies message content with the public key, returning nil for
 // success.
-// Otherwise, it returns ErrVerification.
+// Otherwise, it returns [ErrVerification].
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8
 func (rv *rsaVerifier) Verify(content []byte, signature []byte) error {
@@ -69,7 +69,7 @@ func (rv *rsaVerifier) Verify(content []byte, signature []byte) error {
 
 // VerifyDigest verifies message digest with the public key, returning nil
 // for success.
-// Otherwise, it returns ErrVerification.
+// Otherwise, it returns [ErrVerification].
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8.1
 func (rv *rsaVerifier) VerifyDigest(digest []byte, signature []byte) error {

--- a/sign.go
+++ b/sign.go
@@ -389,7 +389,7 @@ func (m *SignMessage) UnmarshalCBOR(data []byte) error {
 // Sign signs a SignMessage using the provided signers corresponding to the
 // signatures.
 //
-// See `Signature.Sign()` for advanced signing scenarios.
+// See [Signature.Sign] for advanced signing scenarios.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
 //
@@ -433,7 +433,7 @@ func (m *SignMessage) Sign(rand io.Reader, external []byte, signers ...Signer) e
 // Verify verifies the signatures on the SignMessage against the corresponding
 // verifier, returning nil on success or a suitable error if verification fails.
 //
-// See `Signature.Verify()` for advanced verification scenarios like threshold
+// See [Signature.Verify] for advanced verification scenarios like threshold
 // policies.
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4

--- a/sign1.go
+++ b/sign1.go
@@ -233,9 +233,9 @@ func (m *Sign1Message) doUnmarshal(data []byte) error {
 	return nil
 }
 
-// Sign1 signs a Sign1Message using the provided Signer.
+// Sign1 signs a [Sign1Message] using the provided [Signer].
 //
-// This method is a wrapper of `Sign1Message.Sign()`.
+// This method is a wrapper of [Sign1Message.Sign].
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
 func Sign1(rand io.Reader, signer Signer, headers Headers, payload []byte, external []byte) ([]byte, error) {
@@ -280,7 +280,7 @@ func (m *UntaggedSign1Message) UnmarshalCBOR(data []byte) error {
 	return (*Sign1Message)(m).doUnmarshal(data)
 }
 
-// Sign signs an UnttaggedSign1Message using the provided Signer.
+// Sign signs an UnttaggedSign1Message using the provided [Signer].
 // The signature is stored in m.Signature.
 //
 // Note that m.Signature is only valid as long as m.Headers.Protected and
@@ -301,9 +301,9 @@ func (m *UntaggedSign1Message) Verify(external []byte, verifier Verifier) error 
 	return (*Sign1Message)(m).Verify(external, verifier)
 }
 
-// Sign1Untagged signs an UntaggedSign1Message using the provided Signer.
+// Sign1Untagged signs an UntaggedSign1Message using the provided [Signer].
 //
-// This method is a wrapper of `UntaggedSign1Message.Sign()`.
+// This method is a wrapper of [UntaggedSign1Message.Sign].
 //
 // Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-4.4
 func Sign1Untagged(rand io.Reader, signer Signer, headers Headers, payload []byte, external []byte) ([]byte, error) {

--- a/sign1.go
+++ b/sign1.go
@@ -280,7 +280,7 @@ func (m *UntaggedSign1Message) UnmarshalCBOR(data []byte) error {
 	return (*Sign1Message)(m).doUnmarshal(data)
 }
 
-// Sign signs an UnttaggedSign1Message using the provided [Signer].
+// Sign signs an UntaggedSign1Message using the provided [Signer].
 // The signature is stored in m.Signature.
 //
 // Note that m.Signature is only valid as long as m.Headers.Protected and

--- a/signer.go
+++ b/signer.go
@@ -23,7 +23,8 @@ type Signer interface {
 	Sign(rand io.Reader, content []byte) ([]byte, error)
 }
 
-// DigestSigner is an interface for private keys to sign digested COSE signatures.
+// DigestSigner is an interface for private keys to sign digested COSE
+// signatures.
 type DigestSigner interface {
 	// Algorithm returns the signing algorithm associated with the private key.
 	Algorithm() Algorithm
@@ -38,17 +39,18 @@ type DigestSigner interface {
 // The signing key can be a golang built-in crypto private key, a key in HSM, or
 // a remote KMS.
 //
-// Developers are encouraged to implement the `cose.Signer` interface instead of
-// the `crypto.Signer` interface for better performance.
+// Developers are encouraged to implement the [cose.Signer] interface instead of
+// the [crypto.Signer] interface for better performance.
 //
-// All signing keys implementing `crypto.Signer` with `Public()` returning a
-// public key of type `*rsa.PublicKey`, `*ecdsa.PublicKey`, or
-// `ed25519.PublicKey` are accepted.
+// All signing keys implementing [crypto.Signer] with `Public()` returning a
+// public key of type [*rsa.PublicKey], [*ecdsa.PublicKey], or
+// [ed25519.PublicKey] are accepted.
 //
-// The returned signer for rsa and ecdsa keys also implements `cose.DigestSigner`.
+// The returned signer for rsa and ecdsa keys also implements
+// [cose.DigestSigner].
 //
-// Note: `*rsa.PrivateKey`, `*ecdsa.PrivateKey`, and `ed25519.PrivateKey`
-// implement `crypto.Signer`.
+// Note: [*rsa.PrivateKey], [*ecdsa.PrivateKey], and [ed25519.PrivateKey]
+// implement [crypto.Signer].
 func NewSigner(alg Algorithm, key crypto.Signer) (Signer, error) {
 	var errReason string
 	switch alg {
@@ -57,7 +59,8 @@ func NewSigner(alg Algorithm, key crypto.Signer) (Signer, error) {
 		if !ok {
 			return nil, fmt.Errorf("%v: %w", alg, ErrInvalidPubKey)
 		}
-		// RFC 8230 6.1 requires RSA keys having a minimum size of 2048 bits.
+		// RFC 8230 section 6.1 requires RSA keys having a minimum size of 2048
+		// bits.
 		// Reference: https://www.rfc-editor.org/rfc/rfc8230.html#section-6.1
 		if vk.N.BitLen() < 2048 {
 			return nil, errors.New("RSA key must be at least 2048 bits long")

--- a/verifier.go
+++ b/verifier.go
@@ -16,31 +16,32 @@ type Verifier interface {
 
 	// Verify verifies message content with the public key, returning nil for
 	// success.
-	// Otherwise, it returns ErrVerification.
+	// Otherwise, it returns [ErrVerification].
 	//
 	// Reference: https://datatracker.ietf.org/doc/html/rfc8152#section-8
 	Verify(content, signature []byte) error
 }
 
-// DigestVerifier is an interface for public keys to verify digested COSE signatures.
+// DigestVerifier is an interface for public keys to verify digested COSE
+// signatures.
 type DigestVerifier interface {
 	// Algorithm returns the signing algorithm associated with the public key.
 	Algorithm() Algorithm
 
 	// VerifyDigest verifies message digest with the public key, returning nil
 	// for success.
-	// Otherwise, it returns ErrVerification.
+	// Otherwise, it returns [ErrVerification].
 	VerifyDigest(digest, signature []byte) error
 }
 
 // NewVerifier returns a verifier with a given public key.
-// Only golang built-in crypto public keys of type `*rsa.PublicKey`,
-// `*ecdsa.PublicKey`, and `ed25519.PublicKey` are accepted.
-// When `*ecdsa.PublicKey` is specified, its curve must be supported by
+// Only golang built-in crypto public keys of type [*rsa.PublicKey],
+// [*ecdsa.PublicKey], and [ed25519.PublicKey] are accepted.
+// When [*ecdsa.PublicKey] is specified, its curve must be supported by
 // crypto/ecdh.
 //
 // The returned signer for rsa and ecdsa keys also implements
-// `cose.DigestSigner`.
+// [cose.DigestSigner].
 func NewVerifier(alg Algorithm, key crypto.PublicKey) (Verifier, error) {
 	var errReason string
 	switch alg {
@@ -49,7 +50,8 @@ func NewVerifier(alg Algorithm, key crypto.PublicKey) (Verifier, error) {
 		if !ok {
 			return nil, fmt.Errorf("%v: %w", alg, ErrInvalidPubKey)
 		}
-		// RFC 8230 6.1 requires RSA keys having a minimun size of 2048 bits.
+		// RFC 8230 section 6.1 requires RSA keys having a minimum size of 2048
+		// bits.
 		// Reference: https://www.rfc-editor.org/rfc/rfc8230.html#section-6.1
 		if vk.N.BitLen() < 2048 {
 			return nil, errors.New("RSA key must be at least 2048 bits long")


### PR DESCRIPTION
Improves code documentation by
1. Better cross referencing in godoc
2. Fix typos
3. Align comment blocks to fit the line length of 80 characters