### PR TITLE
Normalize EC2 key size at input time to ensure RFC 9053 compliance

### DIFF
--- a/key.go
+++ b/key.go
@@ -476,13 +476,13 @@ func (k Key) validate(op KeyOp) error {
 			}
 
 			// If present, x, y, and d must match the expected size.
-			if len(x) > 0 && len(x) != size {
+			if x != nil && len(x) != size {
 				return errCoordSizeMismatch
 			}
-			if len(y) > 0 && len(y) != size {
+			if y != nil && len(y) != size {
 				return errCoordSizeMismatch
 			}
-			if len(d) > 0 && len(d) != size {
+			if d != nil && len(d) != size {
 				return errCoordSizeMismatch
 			}
 		}
@@ -513,10 +513,10 @@ func (k Key) validate(op KeyOp) error {
 		// If the curve size is known, validate the length of each parameter if present.
 		if size := keySizeOKP(crv); size > 0 {
 			// If present, x and d must match the expected size.
-			if len(x) > 0 && len(x) != size {
+			if x != nil && len(x) != size {
 				return errCoordSizeMismatch
 			}
-			if len(d) > 0 && len(d) != size {
+			if d != nil && len(d) != size {
 				return errCoordSizeMismatch
 			}
 		}

--- a/key.go
+++ b/key.go
@@ -243,6 +243,8 @@ type Key struct {
 }
 
 // NewKeyOKP returns a Key created using the provided Octet Key Pair data.
+// Ed25519 public keys and seeds are fixed-length byte strings,
+// not variable-length integers. Reject incorrect lengths rather than padding.
 func NewKeyOKP(alg Algorithm, x, d []byte) (*Key, error) {
 	if alg != AlgorithmEdDSA {
 		return nil, fmt.Errorf("unsupported algorithm %q", alg)
@@ -314,7 +316,9 @@ func (k *Key) OKP() (crv Curve, x []byte, d []byte) {
 }
 
 // NewKeyEC2 returns a Key created using the provided elliptic curve key
-// data.
+// data. Non-nil x, y, and d are left-padded with zeroes to the size
+// required by the curve, as specified in RFC 9053, Section 7.1.1.
+// An error is returned if any of these parameters exceeds that size.
 func NewKeyEC2(alg Algorithm, x, y, d []byte) (*Key, error) {
 	var curve Curve
 
@@ -623,6 +627,9 @@ func (k *Key) MarshalCBOR() ([]byte, error) {
 }
 
 // UnmarshalCBOR decodes a COSE_Key object into Key.
+// Key parameters must have the lengths required for the key type and curve.
+// Parameters with unexpected lengths are rejected, including those shortened
+// by encoders that omit leading-zero octets in violation of RFC 9053.
 func (k *Key) UnmarshalCBOR(data []byte) error {
 	var tmp map[any]any
 	if err := decMode.Unmarshal(data, &tmp); err != nil {

--- a/key.go
+++ b/key.go
@@ -439,7 +439,7 @@ func (k Key) validate(op KeyOp) error {
 	switch k.Type {
 	case KeyTypeEC2:
 		crv, x, y, d := k.EC2()
-		// Check required paraemeters exist
+		// Check that required parameters are present based on the key operation.
 		switch op {
 		case KeyOpVerify:
 			if x == nil || y == nil {
@@ -454,7 +454,7 @@ func (k Key) validate(op KeyOp) error {
 			return errReqParamsMissing
 		}
 
-		// Then, validate their length if exist and if the size is known
+		// If the curve size is known, validate the length of each parameter if present.
 		if size := curveSize(crv); size > 0 {
 			if len(y) == 0 && len(x) == size+1 {
 				// NOTE: RFC 9053 Section 7.1.1 describes compressed points in COSE_Key
@@ -474,6 +474,8 @@ func (k Key) validate(op KeyOp) error {
 				// Consider revisiting this logic in a future update.
 				return fmt.Errorf("%w: compressed point not supported", ErrInvalidPubKey)
 			}
+
+			// If present, x, y, and d must match the expected size.
 			if len(x) > 0 && len(x) != size {
 				return errCoordSizeMismatch
 			}
@@ -493,7 +495,7 @@ func (k Key) validate(op KeyOp) error {
 		}
 	case KeyTypeOKP:
 		crv, x, d := k.OKP()
-		// Check required paraemeters exist
+		// Check that required parameters are present based on the key operation.
 		switch op {
 		case KeyOpVerify:
 			if x == nil {
@@ -508,7 +510,7 @@ func (k Key) validate(op KeyOp) error {
 			return errReqParamsMissing
 		}
 
-		// Then, validate their length if exist and if the size is known
+		// If present, x and d must match the expected size.
 		if len(x) > 0 && len(x) != ed25519.PublicKeySize {
 			return errCoordSizeMismatch
 		}

--- a/key.go
+++ b/key.go
@@ -336,14 +336,19 @@ func NewKeyEC2(alg Algorithm, x, y, d []byte) (*Key, error) {
 			KeyLabelEC2Curve: curve,
 		},
 	}
+
+	// RFC 9053 Section 7.1.1 says that x and y leading zero octets
+	// MUST be preserved, but the Go crypto/elliptic package trims them.
+	// Since x, y might be used before marshaling, we add 0x00 padding here.
+	size := curveSize(curve)
 	if x != nil {
-		key.Params[KeyLabelEC2X] = x
+		key.Params[KeyLabelEC2X] = append(make([]byte, size-len(x), size), x...)
 	}
 	if y != nil {
-		key.Params[KeyLabelEC2Y] = y
+		key.Params[KeyLabelEC2Y] = append(make([]byte, size-len(y), size), y...)
 	}
 	if d != nil {
-		key.Params[KeyLabelEC2D] = d
+		key.Params[KeyLabelEC2D] = append(make([]byte, size-len(d), size), d...)
 	}
 	if err := key.validate(KeyOpReserved); err != nil {
 		return nil, err

--- a/key.go
+++ b/key.go
@@ -342,12 +342,21 @@ func NewKeyEC2(alg Algorithm, x, y, d []byte) (*Key, error) {
 	// Since x, y might be used before marshaling, we add 0x00 padding here.
 	size := keySizeEC2(curve)
 	if x != nil {
+		if len(x) > size {
+			return nil, fmt.Errorf("%w: x coordinate too long for curve %v", ErrInvalidKey, curve)
+		}
 		key.Params[KeyLabelEC2X] = append(make([]byte, size-len(x), size), x...)
 	}
 	if y != nil {
+		if len(y) > size {
+			return nil, fmt.Errorf("%w: y coordinate too long for curve %v", ErrInvalidKey, curve)
+		}
 		key.Params[KeyLabelEC2Y] = append(make([]byte, size-len(y), size), y...)
 	}
 	if d != nil {
+		if len(d) > size {
+			return nil, fmt.Errorf("%w: d coordinate too long for curve %v", ErrInvalidKey, curve)
+		}
 		key.Params[KeyLabelEC2D] = append(make([]byte, size-len(d), size), d...)
 	}
 	if err := key.validate(KeyOpReserved); err != nil {

--- a/key.go
+++ b/key.go
@@ -453,12 +453,14 @@ func (k Key) validate(op KeyOp) error {
 			return errReqParamsMissing
 		}
 		if size := curveSize(crv); size > 0 {
-			// RFC 8152 Section 13.1.1 says that x and y leading zero octets
-			// MUST be preserved, but the Go crypto/elliptic package trims them.
-			// So we relax the check here to allow for omitted leading zero
-			// octets, we will add them back when marshaling.
-			if len(x) > size || len(y) > size || len(d) > size {
-				return errCoordOverflow
+			if len(y) == 0 && len(x) == size+1 {
+				return fmt.Errorf("%w: compressed point not supported", ErrInvalidPubKey)
+			}
+			if len(x) != size || len(y) != size {
+				return ErrInvalidPubKey
+			}
+			if len(d) > 0 && len(d) != size {
+				return ErrInvalidPrivKey
 			}
 		}
 		switch crv {
@@ -710,9 +712,6 @@ func (k *Key) PrivateKey() (crypto.PrivateKey, error) {
 	switch alg {
 	case AlgorithmES256, AlgorithmES384, AlgorithmES512:
 		_, x, y, d := k.EC2()
-		if len(x) == 0 || len(y) == 0 {
-			return nil, fmt.Errorf("%w: compressed point not supported", ErrInvalidPrivKey)
-		}
 
 		var curve elliptic.Curve
 		switch alg {

--- a/key.go
+++ b/key.go
@@ -340,7 +340,7 @@ func NewKeyEC2(alg Algorithm, x, y, d []byte) (*Key, error) {
 	// RFC 9053 Section 7.1.1 says that x and y leading zero octets
 	// MUST be preserved, but the Go crypto/elliptic package trims them.
 	// Since x, y might be used before marshaling, we add 0x00 padding here.
-	size := curveSize(curve)
+	size := keySizeEC2(curve)
 	if x != nil {
 		key.Params[KeyLabelEC2X] = append(make([]byte, size-len(x), size), x...)
 	}
@@ -455,7 +455,7 @@ func (k Key) validate(op KeyOp) error {
 		}
 
 		// If the curve size is known, validate the length of each parameter if present.
-		if size := curveSize(crv); size > 0 {
+		if size := keySizeEC2(crv); size > 0 {
 			if len(y) == 0 && len(x) == size+1 {
 				// NOTE: RFC 9053 Section 7.1.1 describes compressed points in COSE_Key
 				// using a boolean y-coordinate value (false/true). However, this code
@@ -510,12 +510,15 @@ func (k Key) validate(op KeyOp) error {
 			return errReqParamsMissing
 		}
 
-		// If present, x and d must match the expected size.
-		if len(x) > 0 && len(x) != ed25519.PublicKeySize {
-			return errCoordSizeMismatch
-		}
-		if len(d) > 0 && len(d) != ed25519.SeedSize {
-			return errCoordSizeMismatch
+		// If the curve size is known, validate the length of each parameter if present.
+		if size := keySizeOKP(crv); size > 0 {
+			// If present, x and d must match the expected size.
+			if len(x) > 0 && len(x) != size {
+				return errCoordSizeMismatch
+			}
+			if len(d) > 0 && len(d) != size {
+				return errCoordSizeMismatch
+			}
 		}
 		switch crv {
 		case CurveP256, CurveP384, CurveP521:
@@ -598,7 +601,7 @@ func (k *Key) MarshalCBOR() ([]byte, error) {
 	if k.Type == KeyTypeEC2 {
 		// If EC2 key, ensure that x and y are padded to the correct size.
 		crv, x, y, _ := k.EC2()
-		if size := curveSize(crv); size > 0 {
+		if size := keySizeEC2(crv); size > 0 {
 			if 0 < len(x) && len(x) < size {
 				tmp[KeyLabelEC2X] = append(make([]byte, size-len(x), size), x...)
 			}
@@ -877,9 +880,10 @@ func algorithmFromEllipticCurve(c elliptic.Curve) Algorithm {
 	}
 }
 
-func curveSize(crv Curve) int {
+func keySizeEC2(crv Curve) int {
 	var bitSize int
 	switch crv {
+	// SEC 1: Standards for Efficient Cryptography
 	case CurveP256:
 		bitSize = elliptic.P256().Params().BitSize
 	case CurveP384:
@@ -888,6 +892,25 @@ func curveSize(crv Curve) int {
 		bitSize = elliptic.P521().Params().BitSize
 	}
 	return (bitSize + 7) / 8
+}
+
+func keySizeOKP(crv Curve) int {
+	switch crv {
+	// RFC 8032: Edwards-Curve Digital Signature Algorithm (EdDSA)
+	case CurveEd25519:
+		return ed25519.PublicKeySize // 32
+	case CurveEd448:
+		return 57
+
+	// RFC 7748: Elliptic Curves for Security
+	case CurveX25519:
+		return 32
+	case CurveX448:
+		return 56
+
+	default:
+		return 0
+	}
 }
 
 func decodeBytes(dic map[any]any, lbl any) (b []byte, ok bool, err error) {

--- a/key.go
+++ b/key.go
@@ -427,9 +427,9 @@ var (
 	// The following errors are used multiple times
 	// in Key.validate. We declare them here to avoid
 	// duplication. They are not considered public errors.
-	errCoordOverflow    = fmt.Errorf("%w: overflowing coordinate", ErrInvalidKey)
-	errReqParamsMissing = fmt.Errorf("%w: required parameters missing", ErrInvalidKey)
-	errInvalidCurve     = fmt.Errorf("%w: curve not supported for the given key type", ErrInvalidKey)
+	errCoordSizeMismatch = fmt.Errorf("%w: coordinate size mismatch", ErrInvalidKey)
+	errReqParamsMissing  = fmt.Errorf("%w: required parameters missing", ErrInvalidKey)
+	errInvalidCurve      = fmt.Errorf("%w: curve not supported for the given key type", ErrInvalidKey)
 )
 
 // Validate ensures that the parameters set inside the Key are internally
@@ -439,28 +439,49 @@ func (k Key) validate(op KeyOp) error {
 	switch k.Type {
 	case KeyTypeEC2:
 		crv, x, y, d := k.EC2()
+		// Check required paraemeters exist
 		switch op {
 		case KeyOpVerify:
-			if len(x) == 0 || len(y) == 0 {
+			if x == nil || y == nil {
 				return ErrEC2NoPub
 			}
 		case KeyOpSign:
-			if len(d) == 0 {
+			if d == nil {
 				return ErrNotPrivKey
 			}
 		}
-		if crv == CurveReserved || (len(x) == 0 && len(y) == 0 && len(d) == 0) {
+		if crv == CurveReserved || (x == nil && y == nil && d == nil) {
 			return errReqParamsMissing
 		}
+
+		// Then, validate their length if exist and if the size is known
 		if size := curveSize(crv); size > 0 {
 			if len(y) == 0 && len(x) == size+1 {
+				// NOTE: RFC 9053 Section 7.1.1 describes compressed points in COSE_Key
+				// using a boolean y-coordinate value (false/true). However, this code
+				// currently assumes SEC1-style compression, where 0x02 or 0x03 is prepended
+				// to the x-coordinate.
+				//
+				// This behavior may change in the future, for example, we might compute the
+				// y-coordinate during UnmarshalCBOR, and MarshalCBOR would avoid emitting
+				// compressed points entirely.
+				//
+				// In that case, this conditional may become unnecessary, since the general
+				// length check below (`len(x) > 0 && len(x) != size`) would already catch
+				// invalid compressed input.
+				//
+				// See discussion in https://github.com/veraison/go-cose/pull/223 .
+				// Consider revisiting this logic in a future update.
 				return fmt.Errorf("%w: compressed point not supported", ErrInvalidPubKey)
 			}
-			if len(x) != size || len(y) != size {
-				return ErrInvalidPubKey
+			if len(x) > 0 && len(x) != size {
+				return errCoordSizeMismatch
+			}
+			if len(y) > 0 && len(y) != size {
+				return errCoordSizeMismatch
 			}
 			if len(d) > 0 && len(d) != size {
-				return ErrInvalidPrivKey
+				return errCoordSizeMismatch
 			}
 		}
 		switch crv {
@@ -472,21 +493,27 @@ func (k Key) validate(op KeyOp) error {
 		}
 	case KeyTypeOKP:
 		crv, x, d := k.OKP()
+		// Check required paraemeters exist
 		switch op {
 		case KeyOpVerify:
-			if len(x) == 0 {
+			if x == nil {
 				return ErrOKPNoPub
 			}
 		case KeyOpSign:
-			if len(d) == 0 {
+			if d == nil {
 				return ErrNotPrivKey
 			}
 		}
-		if crv == CurveReserved || (len(x) == 0 && len(d) == 0) {
+		if crv == CurveReserved || (x == nil && d == nil) {
 			return errReqParamsMissing
 		}
-		if (len(x) > 0 && len(x) != ed25519.PublicKeySize) || (len(d) > 0 && len(d) != ed25519.SeedSize) {
-			return errCoordOverflow
+
+		// Then, validate their length if exist and if the size is known
+		if len(x) > 0 && len(x) != ed25519.PublicKeySize {
+			return errCoordSizeMismatch
+		}
+		if len(d) > 0 && len(d) != ed25519.SeedSize {
+			return errCoordSizeMismatch
 		}
 		switch crv {
 		case CurveP256, CurveP384, CurveP521:

--- a/key_test.go
+++ b/key_test.go
@@ -934,6 +934,18 @@ func TestNewNewKeyEC2(t *testing.T) {
 			},
 			wantErr: "",
 		}, {
+			name: "long x", args: args{AlgorithmES256, ec384x, ec256y, ec256d},
+			want:    nil,
+			wantErr: "invalid key: x coordinate too long for curve P-256",
+		}, {
+			name: "long y", args: args{AlgorithmES256, ec256x, ec384y, ec256d},
+			want:    nil,
+			wantErr: "invalid key: y coordinate too long for curve P-256",
+		}, {
+			name: "long d", args: args{AlgorithmES256, ec256x, ec256y, ec384d},
+			want:    nil,
+			wantErr: "invalid key: d coordinate too long for curve P-256",
+		}, {
 			name: "valid ES384", args: args{AlgorithmES384, ec384x, ec384y, ec384d},
 			want: &Key{
 				Type:      KeyTypeEC2,

--- a/key_test.go
+++ b/key_test.go
@@ -1511,7 +1511,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 			},
 			nil,
-			"invalid private key: compressed point not supported",
+			"invalid public key: compressed point not supported",
 		}, {
 			"CurveP256 missing x and y", &Key{
 				Type: KeyTypeEC2,

--- a/key_test.go
+++ b/key_test.go
@@ -1502,6 +1502,17 @@ func TestKey_PrivateKey(t *testing.T) {
 			},
 			"",
 		}, {
+			"CurveP256 compressed x", &Key{
+				Type: KeyTypeEC2,
+				Params: map[any]any{
+					KeyLabelEC2Curve: CurveP256,
+					KeyLabelEC2X:     append([]byte{0x02}, ec256x...),
+					KeyLabelEC2D:     ec256d,
+				},
+			},
+			nil,
+			"invalid private key: compressed point not supported",
+		}, {
 			"CurveP256 missing x and y", &Key{
 				Type: KeyTypeEC2,
 				Params: map[any]any{
@@ -1510,7 +1521,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 			},
 			nil,
-			"invalid private key: compressed point not supported",
+			ErrInvalidPubKey.Error(),
 		}, {
 			"CurveP384", &Key{
 				Type: KeyTypeEC2,
@@ -1632,7 +1643,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 			},
 			nil,
-			"invalid key: overflowing coordinate",
+			ErrInvalidPubKey.Error(),
 		}, {
 			"EC2 incorrect y size", &Key{
 				Type: KeyTypeEC2,
@@ -1644,7 +1655,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 			},
 			nil,
-			"invalid key: overflowing coordinate",
+			ErrInvalidPubKey.Error(),
 		}, {
 			"EC2 incorrect d size", &Key{
 				Type: KeyTypeEC2,
@@ -1656,7 +1667,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 			},
 			nil,
-			"invalid key: overflowing coordinate",
+			ErrInvalidPrivKey.Error(),
 		},
 	}
 	for _, tt := range tests {

--- a/key_test.go
+++ b/key_test.go
@@ -866,6 +866,14 @@ func TestNewKeyOKP(t *testing.T) {
 			name: "x and d missing", args: args{AlgorithmEdDSA, nil, nil},
 			want:    nil,
 			wantErr: "invalid key: required parameters missing",
+		}, {
+			name: "invalid x", args: args{AlgorithmEdDSA, x[:31], d},
+			want:    nil,
+			wantErr: errCoordOverflow.Error(),
+		}, {
+			name: "invalid d", args: args{AlgorithmEdDSA, x, d[:31]},
+			want:    nil,
+			wantErr: errCoordOverflow.Error(),
 		},
 	}
 	for _, tt := range tests {

--- a/key_test.go
+++ b/key_test.go
@@ -883,6 +883,7 @@ func TestNewKeyOKP(t *testing.T) {
 }
 
 func TestNewNewKeyEC2(t *testing.T) {
+	// newEC2 always return the full size []byte
 	ec256x, ec256y, ec256d := newEC2(t, elliptic.P256())
 	ec384x, ec384y, ec384d := newEC2(t, elliptic.P384())
 	ec521x, ec521y, ec521d := newEC2(t, elliptic.P521())
@@ -908,6 +909,19 @@ func TestNewNewKeyEC2(t *testing.T) {
 					KeyLabelEC2X:     ec256x,
 					KeyLabelEC2Y:     ec256y,
 					KeyLabelEC2D:     ec256d,
+				},
+			},
+			wantErr: "",
+		}, {
+			name: "short x, y and d but valid", args: args{AlgorithmES256, ec256x[:31], ec256y[:31], ec256d[:31]},
+			want: &Key{
+				Type:      KeyTypeEC2,
+				Algorithm: AlgorithmES256,
+				Params: map[any]any{
+					KeyLabelEC2Curve: CurveP256,
+					KeyLabelEC2X:     append([]byte{0x00}, ec256x[:31]...),
+					KeyLabelEC2Y:     append([]byte{0x00}, ec256y[:31]...),
+					KeyLabelEC2D:     append([]byte{0x00}, ec256d[:31]...),
 				},
 			},
 			wantErr: "",
@@ -1890,5 +1904,13 @@ func newEC2(t *testing.T, crv elliptic.Curve) (x, y, d []byte) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return priv.X.Bytes(), priv.Y.Bytes(), priv.D.Bytes()
+
+	size := (crv.Params().BitSize + 7) / 8
+	x = make([]byte, size)
+	copy(x[size-len(priv.X.Bytes()):], priv.X.Bytes())
+	y = make([]byte, size)
+	copy(y[size-len(priv.Y.Bytes()):], priv.Y.Bytes())
+	d = make([]byte, size)
+	copy(d[size-len(priv.D.Bytes()):], priv.D.Bytes())
+	return x, y, d
 }

--- a/key_test.go
+++ b/key_test.go
@@ -869,11 +869,11 @@ func TestNewKeyOKP(t *testing.T) {
 		}, {
 			name: "invalid x", args: args{AlgorithmEdDSA, x[:31], d},
 			want:    nil,
-			wantErr: errCoordOverflow.Error(),
+			wantErr: errCoordSizeMismatch.Error(),
 		}, {
 			name: "invalid d", args: args{AlgorithmEdDSA, x, d[:31]},
 			want:    nil,
-			wantErr: errCoordOverflow.Error(),
+			wantErr: errCoordSizeMismatch.Error(),
 		},
 	}
 	for _, tt := range tests {
@@ -1520,8 +1520,15 @@ func TestKey_PrivateKey(t *testing.T) {
 					KeyLabelEC2D:     ec256d,
 				},
 			},
-			nil,
-			ErrInvalidPubKey.Error(),
+			&ecdsa.PrivateKey{
+				PublicKey: ecdsa.PublicKey{
+					Curve: elliptic.P256(),
+					X:     new(big.Int).SetBytes([]byte{}),
+					Y:     new(big.Int).SetBytes([]byte{}),
+				},
+				D: new(big.Int).SetBytes(ec256d),
+			},
+			"",
 		}, {
 			"CurveP384", &Key{
 				Type: KeyTypeEC2,
@@ -1597,7 +1604,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 			},
 			nil,
-			"invalid key: overflowing coordinate",
+			errCoordSizeMismatch.Error(),
 		}, {
 			"OKP incorrect d size", &Key{
 				Type: KeyTypeOKP,
@@ -1608,7 +1615,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 			},
 			nil,
-			"invalid key: overflowing coordinate",
+			errCoordSizeMismatch.Error(),
 		}, {
 			"EC2 missing D", &Key{
 				Type: KeyTypeEC2,
@@ -1643,7 +1650,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 			},
 			nil,
-			ErrInvalidPubKey.Error(),
+			errCoordSizeMismatch.Error(),
 		}, {
 			"EC2 incorrect y size", &Key{
 				Type: KeyTypeEC2,
@@ -1655,7 +1662,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 			},
 			nil,
-			ErrInvalidPubKey.Error(),
+			errCoordSizeMismatch.Error(),
 		}, {
 			"EC2 incorrect d size", &Key{
 				Type: KeyTypeEC2,
@@ -1667,7 +1674,7 @@ func TestKey_PrivateKey(t *testing.T) {
 				},
 			},
 			nil,
-			ErrInvalidPrivKey.Error(),
+			errCoordSizeMismatch.Error(),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
When EC2 keys are represented using `big.Int`, calling `x.Bytes()` may not yield a byte slice of the expected length as specified in RFC 9053, Section 7.1.1 (previously RFC 8152, Section 13.1.1).

Currently, the code adjusts the length of these values (X, Y, D) during `UnmarshalCBOR`, based on the expected size for the given curve. However, it's possible that these fields may be accessed before unmarshaling occurs.
To prevent accidental misuse of incorrectly sized `[]byte` values, this change standardizes the length of these fields before storing them in the Key struct. It also adds validation to ensure the lengths are correct.
One concrete example of where this matters is the COSE Key Thumbprint computation introduced in PR #222, which accesses these fields directly. There may be other similar use cases, and requiring every caller to manually handle length normalization increases the risk of subtle bugs.

Therefore, I propose performing the normalization near NewEC2Key, immediately after calling `Bytes()`, to ensure consistency and safety throughout the codebase.

Commit b9d3c0b3caccac862d3932c034352498658bc2df may warrant further discussion, as it changes the error codes returned and could lead to behavior that differs from what callers of the package expect.
If this change in behavior is not desired, I’m happy to revert it.